### PR TITLE
Fail to add item

### DIFF
--- a/bin/jetty_wait
+++ b/bin/jetty_wait
@@ -1,0 +1,6 @@
+#!/usr/bin/env sh
+
+until $(curl --output /dev/null --silent --head --fail http://localhost:8983/solr); do
+    printf '.'
+    sleep 1
+done

--- a/circle.yml
+++ b/circle.yml
@@ -8,4 +8,4 @@ dependencies:
     - bundle exec rake jetty:clean
     - cd jetty && java -Djetty.port=8983 -Dsolr.solr.home=/home/ubuntu/activefedora-aggregation/jetty/solr -XX:MaxPermSize=128m -Xmx256m -jar start.jar:
         background: true
-    - sleep 20
+    - bin/jetty_wait

--- a/lib/active_fedora/aggregation/proxy_container.rb
+++ b/lib/active_fedora/aggregation/proxy_container.rb
@@ -4,6 +4,10 @@ module ActiveFedora::Aggregation
 
     after_initialize :default_relations
 
+    def self.contained_class
+      "Proxy"
+    end
+
     def parent
       @parent || raise("Parent hasn't been set on #{self.class}")
     end
@@ -42,6 +46,7 @@ module ActiveFedora::Aggregation
         proxy.prev_id = new_proxies[idx-1].id unless idx == 0
       end
 
+      parent.reload
       parent.head = new_proxies.first
       parent.tail = new_proxies.last
       new_proxies.each(&:save)
@@ -52,6 +57,7 @@ module ActiveFedora::Aggregation
     # TODO clear out the old proxies (or reuse them)
     def build_proxies(objects)
       # need to create the proxies before we can add the links otherwise the linked to resource won't exist
+      contained.each(&:destroy)
       objects.map do |object|
         Proxy.create(id: mint_proxy_id, target: object)
       end

--- a/spec/activefedora/association_spec.rb
+++ b/spec/activefedora/association_spec.rb
@@ -47,13 +47,6 @@ describe ActiveFedora::Aggregation::Association do
         expect(image.generic_files).to eq [generic_file2, generic_file1, generic_file3]
       end
 
-      it "should return an updated array of generic_files when generic_files is empty" do
-        current_generic_files = image2.generic_files.container.to_a
-        new_generic_files = current_generic_files + [generic_file3]
-        image2.generic_files = new_generic_files
-        expect(image2.generic_files).to eq [generic_file3]
-      end
-
       it "has a first element" do
         expect(subject.first).to eq generic_file2
       end

--- a/spec/activefedora/association_spec.rb
+++ b/spec/activefedora/association_spec.rb
@@ -50,7 +50,7 @@ describe ActiveFedora::Aggregation::Association do
       it "should return an updated array of generic_files when generic_files is empty" do
         current_generic_files = image2.generic_files.container.to_a
         new_generic_files = current_generic_files + [generic_file3]
-        image.generic_files = new_generic_files
+        image2.generic_files = new_generic_files
         expect(image2.generic_files).to eq [generic_file3]
       end
 

--- a/spec/activefedora/association_spec.rb
+++ b/spec/activefedora/association_spec.rb
@@ -51,7 +51,6 @@ describe ActiveFedora::Aggregation::Association do
         current_generic_files = image2.generic_files.container.to_a
         new_generic_files = current_generic_files + [generic_file3]
         image.generic_files = new_generic_files
-        binding.pry
         expect(image2.generic_files).to eq [generic_file3]
       end
 

--- a/spec/activefedora/association_spec.rb
+++ b/spec/activefedora/association_spec.rb
@@ -47,7 +47,7 @@ describe ActiveFedora::Aggregation::Association do
         expect(image.generic_files).to eq [generic_file2, generic_file1, generic_file3]
       end
 
-      it "should return an updated array of generic_files" do
+      it "should return an updated array of generic_files when generic_files is empty" do
         current_generic_files = image2.generic_files.container.to_a
         new_generic_files = current_generic_files + [generic_file3]
         image.generic_files = new_generic_files

--- a/spec/activefedora/association_spec.rb
+++ b/spec/activefedora/association_spec.rb
@@ -12,6 +12,7 @@ describe ActiveFedora::Aggregation::Association do
   end
   let(:generic_file1) { GenericFile.create }
   let(:generic_file2) { GenericFile.create }
+  let(:generic_file3) { GenericFile.create }
 
   context "with a defined class" do
     before do
@@ -25,10 +26,12 @@ describe ActiveFedora::Aggregation::Association do
     end
 
     let(:image) { Image.create }
+    let(:image2) { Image.create }
 
     before do
       image.generic_files = [generic_file2, generic_file1]
       image.save
+      image2.save
     end
 
     let(:reloaded) { Image.find(image.id) } # because reload doesn't clear this association
@@ -36,6 +39,20 @@ describe ActiveFedora::Aggregation::Association do
     describe "the association" do
       subject { reloaded.generic_files }
       it { is_expected.to eq [generic_file2, generic_file1] }
+
+      it "should return an updated array of generic_files" do
+        current_generic_files = image.generic_files.container.to_a
+        new_generic_files = current_generic_files + [generic_file3]
+        image.generic_files = new_generic_files
+        expect(image.generic_files).to eq [generic_file2, generic_file1, generic_file3]
+      end
+
+      it "should return an updated array of generic_files" do
+        current_generic_files = image2.generic_files.container.to_a
+        new_generic_files = current_generic_files + [generic_file3]
+        image.generic_files = new_generic_files
+        expect(image2.generic_files).to eq [generic_file3]
+      end
 
       it "has a first element" do
         expect(subject.first).to eq generic_file2

--- a/spec/activefedora/association_spec.rb
+++ b/spec/activefedora/association_spec.rb
@@ -51,6 +51,7 @@ describe ActiveFedora::Aggregation::Association do
         current_generic_files = image2.generic_files.container.to_a
         new_generic_files = current_generic_files + [generic_file3]
         image.generic_files = new_generic_files
+        binding.pry
         expect(image2.generic_files).to eq [generic_file3]
       end
 


### PR DESCRIPTION
Adds new tests in association_spec:
- it "should return an updated array of generic_files"
- it "should return an updated array of generic_files when generic_files is empty"

NOTE: In both cases the association container is unchanged.  In the first test, there are two generic_files in the container at the start of the test and two generic_files in the container at the end of the test.  For the second test, the container is empty at the start and end.
