### PR TITLE
Fix Ordered List on Delete

### DIFF
--- a/lib/active_fedora/aggregation.rb
+++ b/lib/active_fedora/aggregation.rb
@@ -15,6 +15,14 @@ module ActiveFedora
       autoload :LinkInserter
       autoload :OrderedReader
       autoload :PersistLinks
+      autoload :OrderedProxy
+      autoload :AppendsToAggregation
+      autoload :ProxyOwner
+      autoload :NullProxy
+      autoload :DecoratingRepository
+      autoload :DecoratorWithArguments
+      autoload :DecoratorList
+      autoload :ProxyRepository
     end
 
     ActiveFedora::Base.include BaseExtension

--- a/lib/active_fedora/aggregation/appends_to_aggregation.rb
+++ b/lib/active_fedora/aggregation/appends_to_aggregation.rb
@@ -1,0 +1,31 @@
+module ActiveFedora::Aggregation
+  class AppendsToAggregation < SimpleDelegator
+    attr_reader :parent_node
+    # @param [#next, #prev] proxy The proxy to add behavior to.
+    # @param [#head, #tail] parent_node The aggregation to append proxies to.
+    def initialize(proxy, parent_node)
+      @parent_node = parent_node
+      super(proxy)
+    end
+
+    def is_a?(klass)
+      __getobj__.is_a?(klass)
+    end
+
+    def save(*args)
+      insert_link do
+        super
+      end
+    end
+
+    private
+
+    def insert_link
+      result = yield
+      if result
+        LinkInserter.new(parent_node, self).call
+      end
+      result
+    end
+  end
+end

--- a/lib/active_fedora/aggregation/association.rb
+++ b/lib/active_fedora/aggregation/association.rb
@@ -1,18 +1,13 @@
 module ActiveFedora::Aggregation
   class Association < ::ActiveFedora::Associations::IndirectlyContainsAssociation
+    delegate :first, :to => :ordered_reader
 
     def ordered_reader
       OrderedReader.new(owner).to_a
     end
 
-    def add_link(proxy)
-      LinkInserter.new(owner, proxy).call
-    end
-
-    def save_through_record(record)
-      super.tap do |proxy|
-        add_link(proxy)
-      end
+    def proxy_class
+      @proxy_class ||= ProxyRepository.new(owner, super)
     end
 
     def options

--- a/lib/active_fedora/aggregation/decorating_repository.rb
+++ b/lib/active_fedora/aggregation/decorating_repository.rb
@@ -1,0 +1,29 @@
+module ActiveFedora::Aggregation
+  ##
+  # Decorates the results of a repository with the given decorator.
+  class DecoratingRepository < SimpleDelegator
+    attr_reader :decorator
+    # @param [#new] decorator A decorator.
+    # @param [#find, #new] base_repository A repository to decorate.
+    def initialize(decorator, base_repository)
+      @decorator = decorator
+      super(base_repository)
+    end
+
+    def find(id)
+      decorate(super(id))
+    end
+
+    def new(*args)
+      result = decorate(super(*args))
+      yield result if block_given?
+      result
+    end
+
+    private
+
+    def decorate(obj)
+      decorator.new(obj)
+    end
+  end
+end

--- a/lib/active_fedora/aggregation/decorator_list.rb
+++ b/lib/active_fedora/aggregation/decorator_list.rb
@@ -1,0 +1,15 @@
+module ActiveFedora::Aggregation
+  # A composite object to allow for a list of decorators to be treated like one.
+  class DecoratorList
+    attr_reader :decorators
+    def initialize(*decorators)
+      @decorators = decorators
+    end
+
+    def new(undecorated_object)
+      decorators.inject(undecorated_object) do |obj, decorator|
+        decorator.new(obj)
+      end
+    end
+  end
+end

--- a/lib/active_fedora/aggregation/decorator_with_arguments.rb
+++ b/lib/active_fedora/aggregation/decorator_with_arguments.rb
@@ -1,0 +1,15 @@
+module ActiveFedora::Aggregation
+  # This is an Adapter to allow a Decorator to respond to the interface #new()
+  # but still require other arguments to instantiate.
+  class DecoratorWithArguments
+    attr_reader :decorator, :args
+    def initialize(decorator, *args)
+      @decorator = decorator
+      @args = args
+    end
+
+    def new(obj)
+      decorator.new(obj, *args)
+    end
+  end
+end

--- a/lib/active_fedora/aggregation/null_proxy.rb
+++ b/lib/active_fedora/aggregation/null_proxy.rb
@@ -1,0 +1,23 @@
+module ActiveFedora::Aggregation
+  # A null proxy to simplify logic.
+  class NullProxy
+    include Singleton
+
+    attr_writer :prev, :next
+    def prev
+      self
+    end
+
+    def next
+      self
+    end
+
+    def reload
+      self
+    end
+
+    def changed?
+      false
+    end
+  end
+end

--- a/lib/active_fedora/aggregation/ordered_proxy.rb
+++ b/lib/active_fedora/aggregation/ordered_proxy.rb
@@ -1,0 +1,57 @@
+module ActiveFedora::Aggregation
+  # A proxy which knows how to delete itself from an aggregation.
+  class OrderedProxy < SimpleDelegator
+    attr_reader :parent_node
+    # @param [#next, #prev, #delete] proxy The proxy to add behavior to.
+    # @param [#delete_proxy!] parent_node The aggregation to delete proxies
+    #   from.
+    def initialize(proxy, parent_node)
+      @parent_node = parent_node
+      super(proxy)
+    end
+
+    def is_a?(klass)
+      __getobj__.is_a?(klass)
+    end
+
+    def delete(*args)
+      link_node_if_true do
+        super
+      end
+    end
+
+    protected
+
+    def link_node_if_true
+      # Have to precache these or AF tries to access this node?
+      next_or_null
+      prev_or_null
+      yield.tap do |result|
+        if result
+          # Have to reload proxies because otherwise you persist them with bad
+          # referencing triples.
+          [next_or_null, prev_or_null, parent_node].each(&:reload)
+          prev_or_null.next = self.next
+          next_or_null.prev = prev
+          changed_nodes.each(&:save!)
+          parent_node.delete_proxy!(self)
+        end
+      end
+    end
+
+    def next_or_null
+      self.next || NullProxy.instance
+    end
+
+    def prev_or_null
+      self.prev || NullProxy.instance
+    end
+
+    private
+
+    def changed_nodes
+      [self.prev, self.next].uniq.compact.select(&:changed?)
+    end
+
+  end
+end

--- a/lib/active_fedora/aggregation/proxy_owner.rb
+++ b/lib/active_fedora/aggregation/proxy_owner.rb
@@ -1,0 +1,20 @@
+module ActiveFedora::Aggregation
+  ##
+  # Decorates a proxy owner such that it knows how to delete a proxy from its
+  # ordered list.
+  class ProxyOwner < SimpleDelegator
+    # @param [#next, #prev] proxy A Proxy link to delete.
+    def delete_proxy!(proxy)
+      if proxy == head || head.nil? # Head is nil if proxy is now deleted.
+        self.head = proxy.next
+      end
+      if proxy == tail || tail.nil? # Head is nil if proxy is now deleted.
+        self.tail = proxy.prev
+      end
+      [head, tail].uniq.compact.each(&:reload)
+      if changed?
+        save!
+      end
+    end
+  end
+end

--- a/lib/active_fedora/aggregation/proxy_repository.rb
+++ b/lib/active_fedora/aggregation/proxy_repository.rb
@@ -1,0 +1,38 @@
+module ActiveFedora::Aggregation
+  ##
+  # Repository for Proxies. This repository is responsible for decorating a
+  # proxy such that it's useful for aggregation and is an attempt at
+  # centralizing hard-coded dependencies without a dependency injection
+  # container.
+  class ProxyRepository < SimpleDelegator
+    attr_reader :owner, :base_proxy_factory
+    # @param [ActiveFedora::Base] owner The node which proxy will assert order
+    #   on.
+    # @param [#find, #new] base_proxy_factory The base factory which returns proxies
+    #   that will be decorated.
+    # @return [#find, #new] A repository which can return proxies useful for
+    #  aggregation.
+    def initialize(owner, base_proxy_factory)
+      @owner = owner
+      @base_proxy_factory = base_proxy_factory
+      super(repository)
+    end
+
+    private
+
+    def repository
+      DecoratingRepository.new(proxy_decorator, base_proxy_factory)
+    end
+
+    def proxy_decorator
+      DecoratorList.new(
+        DecoratorWithArguments.new(OrderedProxy, proxy_owner),
+        DecoratorWithArguments.new(AppendsToAggregation, proxy_owner)
+      )
+    end
+
+    def proxy_owner
+      @proxy_owner ||= ProxyOwner.new(owner)
+    end
+  end
+end

--- a/spec/active_fedora/aggregation/appends_to_aggregation_spec.rb
+++ b/spec/active_fedora/aggregation/appends_to_aggregation_spec.rb
@@ -1,0 +1,41 @@
+require 'spec_helper'
+
+RSpec.describe ActiveFedora::Aggregation::AppendsToAggregation do
+  subject { described_class.new(proxy, aggregation) }
+  let(:proxy) { object_double(ActiveFedora::Aggregation::Proxy.new) }
+  let(:aggregation) { object_double(ActiveFedora::Base) }
+
+  describe "#is_a?" do
+    # Necessary for association setting.
+    it "should return true for the aggregation class" do
+      expect(subject.is_a?(aggregation.class)).to eq true
+    end
+  end
+
+  describe "#save" do
+    context "when the proxy fails to save" do
+      it "should not add the link" do
+        allow(proxy).to receive(:save).and_return(false)
+        allow(ActiveFedora::Aggregation::LinkInserter).to receive(:new)
+
+        subject.save
+
+        expect(ActiveFedora::Aggregation::LinkInserter).not_to have_received(:new)
+      end
+    end
+    context "when the proxy saves" do
+      it "should add the link" do
+        # A lot of stubbing necessary - refactoring probably necessary.
+        allow(proxy).to receive(:save).and_return(true)
+        link_inserter = instance_double(ActiveFedora::Aggregation::LinkInserter)
+        allow(ActiveFedora::Aggregation::LinkInserter).to receive(:new).and_return(link_inserter)
+        allow(link_inserter).to receive(:call)
+
+        subject.save
+
+        expect(ActiveFedora::Aggregation::LinkInserter).to have_received(:new).with(aggregation, proxy)
+        expect(link_inserter).to have_received(:call)
+      end
+    end
+  end
+end

--- a/spec/active_fedora/aggregation/decorating_repository_spec.rb
+++ b/spec/active_fedora/aggregation/decorating_repository_spec.rb
@@ -1,0 +1,38 @@
+require 'spec_helper'
+
+RSpec.describe ActiveFedora::Aggregation::DecoratingRepository do
+  subject { described_class.new(decorator, base_repository) }
+  # Responds to new and returns a decorated asset
+  let(:decorator) { double("decorator") }
+  # Responds to #new and #find and returns an asset
+  let(:base_repository) { double("repository") }
+
+  describe "#new" do
+    it "should return a decorated asset from base_repository" do
+      asset = double("asset")
+      decorated_asset = double("decorated_asset")
+      allow(base_repository).to receive(:new).and_return(asset)
+      allow(decorator).to receive(:new).with(asset).and_return(decorated_asset)
+
+      expect(subject.new).to eq decorated_asset
+    end
+    it "should pass on arguments to base_repository" do
+      allow(base_repository).to receive(:new)
+      allow(decorator).to receive(:new)
+
+      subject.new(:test => 1)
+      expect(base_repository).to have_received(:new).with(:test => 1)
+    end
+  end
+  describe "#find" do
+    it "should return a decorated asset from base_repository" do
+      id = double("id")
+      asset = double("asset")
+      decorated_asset = double("decorated_asset")
+      allow(base_repository).to receive(:find).with(id).and_return(asset)
+      allow(decorator).to receive(:new).with(asset).and_return(decorated_asset)
+
+      expect(subject.find(id)).to eq decorated_asset
+    end
+  end
+end

--- a/spec/active_fedora/aggregation/decorator_list_spec.rb
+++ b/spec/active_fedora/aggregation/decorator_list_spec.rb
@@ -1,0 +1,26 @@
+require 'spec_helper'
+
+RSpec.describe ActiveFedora::Aggregation::DecoratorList do
+  subject { described_class.new(decorator_1, decorator_2) }
+  let(:decorator_1) { build_decorator }
+  let(:decorator_2) { build_decorator }
+
+  describe "#new" do
+    it "should chain decorations" do
+      asset = double("asset")
+      decorated = double("decorated_asset")
+      allow(decorator_1).to receive(:new).and_return(decorated)
+
+      subject.new(asset)
+
+      expect(decorator_1).to have_received(:new).with(asset)
+      expect(decorator_2).to have_received(:new).with(decorated)
+    end
+  end
+
+  def build_decorator
+    d = double("decorator")
+    allow(d).to receive(:new)
+    d
+  end
+end

--- a/spec/active_fedora/aggregation/decorator_with_arguments_spec.rb
+++ b/spec/active_fedora/aggregation/decorator_with_arguments_spec.rb
@@ -1,0 +1,21 @@
+require 'spec_helper'
+
+RSpec.describe ActiveFedora::Aggregation::DecoratorWithArguments do
+  subject { described_class.new(decorator, argument_1, argument_2) }
+  let(:decorator) { double("decorator") }
+  let(:argument_1) { double("argument1") }
+  let(:argument_2) { double("argument2") }
+
+  describe "#new" do
+    it "should call #new on decorator with arguments" do
+      asset = double("asset")
+      decorated = double("decorated_asset")
+      allow(decorator).to receive(:new).and_return(decorated)
+
+      result = subject.new(asset)
+
+      expect(decorator).to have_received(:new).with(asset, argument_1, argument_2)
+      expect(result).to eq decorated
+    end
+  end
+end

--- a/spec/active_fedora/aggregation/null_proxy_spec.rb
+++ b/spec/active_fedora/aggregation/null_proxy_spec.rb
@@ -1,0 +1,48 @@
+require 'spec_helper'
+
+RSpec.describe ActiveFedora::Aggregation::NullProxy do
+  subject { described_class.instance }
+  describe "#prev" do
+    it "should return itself" do
+      expect(subject.prev).to eq subject
+    end
+  end
+
+  describe "#next" do
+    it "should return itself" do
+      expect(subject.next).to eq subject
+    end
+  end
+
+  describe "#next=" do
+    it "shouldn't work" do
+      subject.next = "bla"
+
+      expect(subject.next).to eq subject
+    end
+  end
+
+  describe "#prev=" do
+    it "shouldn't work" do
+      subject.prev = "bla"
+
+      expect(subject.prev).to eq subject
+    end
+  end
+
+  describe "#reload" do
+    it "should return itself" do
+      expect(subject.reload).to eq subject
+    end
+  end
+
+  describe "#changed?" do
+    it "should be false" do
+      expect(subject).not_to be_changed
+    end
+    it "should be false when prev is set" do
+      subject.prev = "bla"
+      expect(subject).not_to be_changed
+    end
+  end
+end

--- a/spec/active_fedora/aggregation/ordered_proxy_spec.rb
+++ b/spec/active_fedora/aggregation/ordered_proxy_spec.rb
@@ -1,0 +1,90 @@
+require 'spec_helper'
+
+RSpec.describe ActiveFedora::Aggregation::OrderedProxy do
+  subject { described_class.new(proxy, aggregation) }
+  let(:proxy) { object_double(ActiveFedora::Aggregation::Proxy.new) }
+  let(:aggregation) { object_double(ActiveFedora::Aggregation::ProxyOwner.new(ActiveFedora::Base.new), :delete_proxy! => nil, :reload => nil) }
+
+  describe "#is_a?" do
+    # Necessary to set this as an association point
+    it "should be true for the aggregation's class" do
+      expect(subject.is_a?(aggregation.class)).to eq true
+    end
+  end
+
+  describe "#delete" do
+    it "should set next/prev" do
+      # Yikes - Law of Demeter violation. Can we avoid it? Decorate proxy when
+      # incoming? Add the delegation methods to our proxy object?
+      next_proxy = build_proxy(name: "next")
+      prev_proxy = build_proxy(name: "prev")
+      stub_proxy(next_proxy: next_proxy, prev_proxy: prev_proxy)
+
+      subject.delete
+
+      expect(next_proxy).to have_received(:prev=).with(prev_proxy)
+      expect(prev_proxy).to have_received(:next=).with(next_proxy)
+    end
+    it "should call delete_proxy!" do
+      stub_proxy
+
+      subject.delete
+
+      expect(aggregation).to have_received(:delete_proxy!).with(subject)
+    end
+    it "should call delete on the source proxy" do
+      stub_proxy
+
+      subject.delete
+
+      expect(proxy).to have_received(:delete)
+    end
+    it "should return the result of the owner's delete call" do
+      stub_proxy
+      delete_result = double("result")
+      allow(proxy).to receive(:delete).and_return(delete_result)
+      
+      result = subject.delete
+
+      expect(result).to eq delete_result
+    end
+    context "and the next node changed" do
+      it "should save it" do
+        next_proxy = build_proxy(name: "next", changed: true)
+        prev_proxy = build_proxy(name: "prev", changed: false)
+        stub_proxy(next_proxy: next_proxy)
+
+        subject.delete
+
+        expect(next_proxy).to have_received(:save!)
+        expect(prev_proxy).not_to have_received(:save!)
+      end
+    end
+    context "and the proxy delete fails" do
+      it "should not delete the proxy" do
+        stub_proxy
+        allow(proxy).to receive(:delete).and_return(false)
+
+        subject.delete
+
+        expect(aggregation).not_to have_received(:delete_proxy!)
+      end
+    end
+  end
+
+  def stub_proxy(next_proxy: nil, prev_proxy: nil)
+    allow(proxy).to receive(:next).and_return(next_proxy)
+    allow(proxy).to receive(:prev).and_return(prev_proxy)
+    allow(proxy).to receive(:delete).and_return(true)
+  end
+
+  def build_proxy(name:, changed: false)
+    proxy = double(name)
+    allow(proxy).to receive(:prev=)
+    allow(proxy).to receive(:next=)
+    allow(proxy).to receive(:changed?).and_return(changed)
+    allow(proxy).to receive(:save!)
+    allow(proxy).to receive(:reload)
+    proxy
+  end
+end

--- a/spec/active_fedora/aggregation/proxy_owner_spec.rb
+++ b/spec/active_fedora/aggregation/proxy_owner_spec.rb
@@ -1,0 +1,68 @@
+require 'spec_helper'
+
+RSpec.describe ActiveFedora::Aggregation::ProxyOwner do
+  before do
+    class ExampleAggregation < ActiveFedora::Base
+      aggregates :members
+    end
+  end
+  after do
+    Object.send(:remove_const, :ExampleAggregation)
+  end
+
+  describe "#delete_proxy!" do
+    context "if head is equal to the proxy" do
+      it "should set head to proxy's next" do
+        next_proxy = build_proxy
+        proxy = build_proxy(next_proxy: next_proxy)
+        aggregation = build_aggregation(head: proxy)
+        decorated_owner = described_class.new(aggregation)
+
+        decorated_owner.delete_proxy!(proxy)
+
+        expect(aggregation).to have_received(:head=).with(next_proxy)
+      end
+    end
+    context "if tail is equal to the proxy" do
+      it "should set tail to proxy's previous" do
+        prev_proxy = build_proxy
+        proxy = build_proxy(prev_proxy: prev_proxy)
+        aggregation = build_aggregation(tail: proxy)
+        decorated_owner = described_class.new(aggregation)
+
+        decorated_owner.delete_proxy!(proxy)
+
+        expect(aggregation).to have_received(:tail=).with(prev_proxy)
+      end
+    end
+    context "if it's changed" do
+      it "should save" do
+        aggregation = build_aggregation(changed: true)
+        decorated_owner = described_class.new(aggregation)
+
+        decorated_owner.delete_proxy!(build_proxy)
+
+        expect(aggregation).to have_received(:save!)
+      end
+    end
+
+    def build_proxy(next_proxy:nil, prev_proxy:nil)
+      proxy = object_double(ActiveFedora::Aggregation::Proxy.new)
+      allow(proxy).to receive(:next).and_return(next_proxy)
+      allow(proxy).to receive(:prev).and_return(prev_proxy)
+      allow(proxy).to receive(:reload)
+      proxy
+    end
+
+    def build_aggregation(head: nil, tail: nil, changed: false)
+      aggregation = object_double(ExampleAggregation.new)
+      allow(aggregation).to receive(:head=)
+      allow(aggregation).to receive(:tail=)
+      allow(aggregation).to receive(:head).and_return(head)
+      allow(aggregation).to receive(:tail).and_return(tail)
+      allow(aggregation).to receive(:changed?).and_return(changed)
+      allow(aggregation).to receive(:save!)
+      aggregation
+    end
+  end
+end

--- a/spec/activefedora/association_spec.rb
+++ b/spec/activefedora/association_spec.rb
@@ -37,6 +37,29 @@ describe ActiveFedora::Aggregation::Association do
       it "has persisted the association" do
         expect(image.reload.generic_files).to eq [generic_file1, generic_file2]
       end
+      it "should be able to delete" do
+        image.generic_files = [generic_file1]
+        expect(reloaded.generic_files).to eq [generic_file1]
+        expect(reloaded.ordered_generic_files).to eq [generic_file1]
+      end
+      it "should be able to be emptied" do
+        image.generic_files = []
+        image.save!
+        expect(reloaded.generic_files).to eq []
+        expect(reloaded.ordered_generic_files).to eq []
+      end
+      it "should be able to delete a node in the middle" do
+        image.generic_files << generic_file3
+        image.save
+        image.generic_files = [ generic_file2, generic_file3 ]
+        expect(image.ordered_generic_files).to eq [generic_file2, generic_file3]
+        expect(reloaded.generic_files).to eq [generic_file2, generic_file3]
+        expect(reloaded.ordered_generic_files).to eq [generic_file2, generic_file3]
+      end
+
+      it "has a first element" do
+        expect(reloaded.generic_files.first).to eq generic_file1
+      end
     end
 
     context "a persisted record" do


### PR DESCRIPTION
Closes #21

This uses the proxy's interface rather than a service object. It's moderately complex, if it's too much so I can just override delete_records to do all this and we can support that.
