### PR TITLE
automatically save associacted records when the parent is saved

### DIFF
--- a/lib/active_fedora/aggregation.rb
+++ b/lib/active_fedora/aggregation.rb
@@ -12,10 +12,11 @@ module ActiveFedora
       autoload :Builder
       autoload :Reflection
       autoload :BaseExtension
-      autoload :OrderedReader
       autoload :LinkInserter
+      autoload :OrderedReader
+      autoload :PersistLinks
     end
 
-    ActiveFedora::Base.extend BaseExtension
+    ActiveFedora::Base.include BaseExtension
   end
 end

--- a/lib/active_fedora/aggregation/base_extension.rb
+++ b/lib/active_fedora/aggregation/base_extension.rb
@@ -1,23 +1,36 @@
 module ActiveFedora::Aggregation
   module BaseExtension
+    extend ActiveSupport::Concern
+    include PersistLinks
 
-    ##
-    # Create an aggregation association on the class
-    # @example
-    #   class Image < ActiveFedora::Base
-    #     aggregates :generic_files
-    #   end
-    def aggregates(name, options={})
-      Builder.build(self, name, options)
-    end
+    module ClassMethods
+      ##
+      # Create an aggregation association on the class
+      # @example
+      #   class Image < ActiveFedora::Base
+      #     aggregates :generic_files
+      #   end
+      def aggregates(name, options={})
+        Builder.build(self, name, options)
+      end
 
-    def create_reflection(macro, name, options, active_fedora)
-      if macro == :aggregation
-        Reflection.new(macro, name, options, active_fedora).tap do |reflection|
-          add_reflection name, reflection
+      def create_reflection(macro, name, options, active_fedora)
+        if macro == :aggregation
+          Reflection.new(macro, name, options, active_fedora).tap do |reflection|
+            add_reflection name, reflection
+          end
+        else
+          super
         end
-      else
-        super
+      end
+
+      def setup_persist_links_callback(reflection)
+        save_method = :"autosave_aggregation_links_for_#{reflection.name}"
+        define_non_cyclic_method(save_method, reflection) { persist_aggregation_links }
+
+        # Doesn't use after_save because we need this callback to come after the autosave callback
+        after_create save_method
+        after_update save_method
       end
     end
   end

--- a/lib/active_fedora/aggregation/builder.rb
+++ b/lib/active_fedora/aggregation/builder.rb
@@ -1,5 +1,6 @@
 module ActiveFedora::Aggregation
   class Builder < ActiveFedora::Associations::Builder::CollectionAssociation
+    include ActiveFedora::AutosaveAssociation::AssociationBuilderExtension
     self.macro = :aggregation
 
     def build
@@ -7,6 +8,7 @@ module ActiveFedora::Aggregation
       model.belongs_to :head, predicate: ::RDF::Vocab::IANA['first'], class_name: 'ActiveFedora::Aggregation::Proxy'
       model.belongs_to :tail, predicate: ::RDF::Vocab::IANA.last, class_name: 'ActiveFedora::Aggregation::Proxy'
 
+      model.send(:setup_persist_links_callback, reflection)
       reflection
     end
 

--- a/lib/active_fedora/aggregation/link_inserter.rb
+++ b/lib/active_fedora/aggregation/link_inserter.rb
@@ -27,7 +27,7 @@ module ActiveFedora::Aggregation
     end
 
     def persist_nodes!
-      [root, root.tail, proxy, proxy.prev].uniq.compact.each(&:save!)
+      [proxy, proxy.prev].uniq.compact.each(&:save!)
     end
 
     class Appender

--- a/lib/active_fedora/aggregation/persist_links.rb
+++ b/lib/active_fedora/aggregation/persist_links.rb
@@ -1,0 +1,9 @@
+module ActiveFedora::Aggregation
+  module PersistLinks
+    # If the head or tail pointer was updated (in an autosave callback), then persist them
+    def persist_aggregation_links
+      return true unless @new_record_before_save
+      save if changes.key?("head_id") or changes.key?("tail_id")
+    end
+  end
+end

--- a/spec/activefedora/association_spec.rb
+++ b/spec/activefedora/association_spec.rb
@@ -25,52 +25,65 @@ describe ActiveFedora::Aggregation::Association do
       Object.send(:remove_const, :Image)
     end
 
-    let(:image) { Image.create }
-
-    before do
-      image.generic_files = [generic_file2, generic_file1]
-      image.save
-    end
-
     let(:reloaded) { Image.find(image.id) } # because reload doesn't clear this association
 
-    describe "the association" do
-      subject { reloaded.generic_files }
-      it { is_expected.to eq [generic_file2, generic_file1] }
-
-      it "should return an updated array of generic_files" do
-        current_generic_files = image.generic_files.to_a
-        new_generic_files = current_generic_files + [generic_file3]
-        image.generic_files = new_generic_files
-        expect(image.generic_files).to eq [generic_file2, generic_file1, generic_file3]
+    context "a new record, once saved" do
+      let(:image) { Image.new }
+      before do
+        image.generic_files = [generic_file1, generic_file2]
+        image.save
       end
 
-      it "has a first element" do
-        expect(subject.first).to eq generic_file2
-      end
-
-      it "uses the default predicate" do
-        expect(reloaded.resource.query(predicate: ::RDF::Vocab::ORE.aggregates).count).to eq 2
-      end
-      it "associates directly to aggregated resource" do
-        expect(reloaded.resource.query(predicate: ::RDF::Vocab::ORE.aggregates).to_a.first.object).to eq generic_file2.resource.rdf_subject
+      it "has persisted the association" do
+        expect(image.reload.generic_files).to eq [generic_file1, generic_file2]
       end
     end
 
-    describe "#ordered_*" do
-      it "should return an ordered array" do
-        expect(reloaded.ordered_generic_files).to eq [generic_file2, generic_file1]
+    context "a persisted record" do
+      let(:image) { Image.create }
+      before do
+        image.generic_files = [generic_file2, generic_file1]
+        image.save
       end
-    end
 
-    describe "#head" do
-      it "returns the first proxy" do
-        expect(reloaded.head).to be_kind_of ActiveFedora::Aggregation::Proxy
+      describe "the association" do
+        subject { reloaded.generic_files }
+        it { is_expected.to eq [generic_file2, generic_file1] }
+
+        it "returns an updated array of generic_files" do
+          current_generic_files = image.generic_files.to_a
+          new_generic_files = current_generic_files + [generic_file3]
+          image.generic_files = new_generic_files
+          expect(image.generic_files).to eq [generic_file2, generic_file1, generic_file3]
+        end
+
+        it "has a first element" do
+          expect(subject.first).to eq generic_file2
+        end
+
+        it "uses the default predicate" do
+          expect(reloaded.resource.query(predicate: ::RDF::Vocab::ORE.aggregates).count).to eq 2
+        end
+        it "associates directly to aggregated resource" do
+          expect(reloaded.resource.query(predicate: ::RDF::Vocab::ORE.aggregates).to_a.first.object).to eq generic_file2.resource.rdf_subject
+        end
       end
-    end
-    describe "#head_id" do
-      it "returns the first proxy" do
-        expect(reloaded.head_id).to be_kind_of String
+
+      describe "#ordered_*" do
+        it "should return an ordered array" do
+          expect(reloaded.ordered_generic_files).to eq [generic_file2, generic_file1]
+        end
+      end
+
+      describe "#head" do
+        it "returns the first proxy" do
+          expect(reloaded.head).to be_kind_of ActiveFedora::Aggregation::Proxy
+        end
+      end
+      describe "#head_id" do
+        it "returns the first proxy" do
+          expect(reloaded.head_id).to be_kind_of String
+        end
       end
     end
   end


### PR DESCRIPTION
example:

``` ruby
  class Post < ActiveFedora::Base
    aggregates :comments
  end

  post = Post.new(title: 'ruby rocks')
  post.comments.build(body: 'hello world')
  post.save # => saves both post and comment
```
