### PR TITLE
Pass association to validator.

### DIFF
--- a/lib/active_fedora/aggregation/association.rb
+++ b/lib/active_fedora/aggregation/association.rb
@@ -72,7 +72,7 @@ module ActiveFedora::Aggregation
     def raise_on_type_mismatch(record)
       super
       if type_validator
-        type_validator.validate!(record)
+        type_validator.validate!(self,record)
       end
     end
 

--- a/spec/activefedora/association_spec.rb
+++ b/spec/activefedora/association_spec.rb
@@ -299,7 +299,7 @@ describe ActiveFedora::Aggregation::Association do
       class Image < ActiveFedora::Base
         aggregates :files, type_validator: TypeValidator
       end
-      allow(TypeValidator).to receive(:validate!).with(image).and_raise ActiveFedora::AssociationTypeMismatch
+      allow(TypeValidator).to receive(:validate!).with(parent.association(:files),image).and_raise ActiveFedora::AssociationTypeMismatch
     end
     after do
       Object.send(:remove_const, :Image)


### PR DESCRIPTION
Needed more context in Hydra::PCDM to avoid overriding methods.
