### PR TITLE
Handle proxies that don't point at any object

### DIFF
--- a/lib/active_fedora/aggregation/association.rb
+++ b/lib/active_fedora/aggregation/association.rb
@@ -56,7 +56,13 @@ module ActiveFedora::Aggregation
       index = remainder.find_index { |n| n.fetch('id') == first_id }
       first = remainder.delete_at(index)
       next_id = first['next_ssim'].try(:first)
-      create_linked_list(next_id, remainder, list + [first.fetch('proxyFor_ssim').first])
+      proxy_for = first.fetch('proxyFor_ssim', []).first
+      if proxy_for
+        create_linked_list(next_id, remainder, list + [proxy_for])
+      else
+        ActiveFedora::Base.logger.error("Found a proxy (id: #{first['id']}) that has no proxyFor_ssim") if ActiveFedora::Base.logger
+        create_linked_list(next_id, remainder, list)
+      end
     end
 
     def default_options

--- a/spec/activefedora/association_spec.rb
+++ b/spec/activefedora/association_spec.rb
@@ -25,6 +25,26 @@ describe ActiveFedora::Aggregation::Association do
       Object.send(:remove_const, :Image)
     end
 
+    describe "#create_linked_list" do
+      let(:image) { Image.new }
+      let(:association) { image.association(:generic_files) }
+      let(:proxies) { [{ 'id' => head_id, 'proxyIn_ssim' => ['987'], 'next_ssim' => ['456'] },
+                       { 'id' => '456', 'proxyIn_ssim' => ['987'], 'proxyFor_ssim' => ['555'] }] }
+      let(:head_id) { '123' }
+      let(:logger) { Logger.new(STDERR) }
+      before do
+        ActiveFedora::Base.logger = logger
+      end
+
+      context "when there's a proxy that doesn't point at any object" do
+        it "logs an error and returns ids of those that exist" do
+          expect(logger).to receive(:error).with("Found a proxy (id: 123) that has no proxyFor_ssim")
+          val = association.send(:create_linked_list, head_id, proxies)
+          expect(val).to eq ['555']
+        end
+      end
+    end
+
     describe "#delete" do
       let(:image) { Image.new }
       let(:file) { GenericFile.new }


### PR DESCRIPTION
CurationConcerns was nullifying the proxyFor assertion in some cases,
this allows aggregations to handle this bad data by logging the error
and without raising a stack trace.
