### PR TITLE
Split Ordering from Membership

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,15 +15,30 @@ end
 
 generic_file1 = GenericFile.create(id: 'file1')
 generic_file2 = GenericFile.create(id: 'file2')
+generic_file3 = GenericFile.create(id: 'file2')
 
 class Image < ActiveFedora::Base
-  aggregates :generic_files
+  ordered_aggregation :generic_files, through: :list_source
 end
 
 image = Image.create(id: 'my_image')
-image.generic_files = [generic_file2, generic_file1]
+image.ordered_generic_file_proxies.append_target generic_file2
+image.ordered_generic_file_proxies.append_target generic_file1
 image.save
+image.generic_files # => [generic_file2, generic_file]
+image.ordered_generic_files # => [generic_file2, generic_file]
 
+# Not all generic files must be ordered.
+image.generic_files += [generic_file3]
+image.generic_files # => [generic_file2, generic_file, generic_file3]
+image.ordered_generic_files # => [generic_file2, generic_file]
+
+# non-ordered accessor is not ordered.
+image.ordered_generic_file_proxies.insert_at(0, generic_file3)
+image.generic_files # => [generic_file2, generic_file, generic_file3]
+image.ordered_generic_files # => [generic_file3, generic_file2, generic_file]
+
+# Deletions
+image.ordered_generic_file_proxies.delete_at(1)
+image.ordered_generic_files # => [generic_file3, generic_file]
 ```
-
-Now the `generic_files` method returns an ordered list of GenericFile objects.

--- a/activefedora-aggregation.gemspec
+++ b/activefedora-aggregation.gemspec
@@ -19,6 +19,9 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'activesupport'
   spec.add_dependency 'active-fedora'
   spec.add_dependency 'rdf-vocab', '~> 0.8.1'
+  # Lock to RDF 1.1.16 because 1.1.17 causes a bug from ruby 2.2
+  # https://github.com/ruby-rdf/rdf/pull/213
+  spec.add_dependency 'rdf', '~>1.1.16.0'
 
   spec.add_development_dependency "bundler", "~> 1.8"
   spec.add_development_dependency "rake", "~> 10.0"

--- a/lib/active_fedora/aggregation.rb
+++ b/lib/active_fedora/aggregation.rb
@@ -3,6 +3,7 @@ require 'active_support'
 require 'active-fedora'
 require 'rdf/vocab'
 require 'active_fedora/filter'
+require 'active_fedora/orders'
 
 module ActiveFedora
   module Aggregation
@@ -25,6 +26,7 @@ module ActiveFedora
       autoload :DecoratorWithArguments
       autoload :DecoratorList
       autoload :ProxyRepository
+      autoload :ListSource
     end
 
     ActiveFedora::Base.include BaseExtension

--- a/lib/active_fedora/aggregation/association.rb
+++ b/lib/active_fedora/aggregation/association.rb
@@ -3,7 +3,7 @@ module ActiveFedora::Aggregation
     delegate :first, to: :ordered_reader
 
     def ordered_reader
-      OrderedReader.new(owner).to_a
+      OrderedReader.new(owner).to_a.map(&:target)
     end
 
     def proxy_class

--- a/lib/active_fedora/aggregation/base_extension.rb
+++ b/lib/active_fedora/aggregation/base_extension.rb
@@ -33,6 +33,28 @@ module ActiveFedora::Aggregation
       end
 
       ##
+      # Allows ordering of an association
+      # @example
+      #   class Image < ActiveFedora::Base
+      #     contains :list_resource, class_name:
+      #       "ActiveFedora::Aggregation::ListSource"
+      #     orders :generic_files, through: :list_resource
+      #   end
+      def orders(name, options={})
+        ActiveFedora::Orders::Builder.build(self, name, options)
+      end
+
+      ##
+      # Convenience method for building an ordered aggregation.
+      # @example
+      #   class Image < ActiveFedora::Base
+      #     ordered_aggregation :members, through: :list_source
+      #   end
+      def ordered_aggregation(name, options={})
+        ActiveFedora::Orders::AggregationBuilder.build(self, name, options)
+      end
+
+      ##
       # Create an association filter on the class
       # @example
       #   class Image < ActiveFedora::Base
@@ -52,6 +74,10 @@ module ActiveFedora::Aggregation
           end
         when :filter
           ActiveFedora::Filter::Reflection.new(macro, name, options, active_fedora).tap do |reflection|
+            add_reflection name, reflection
+          end
+        when :orders
+          ActiveFedora::Orders::Reflection.new(macro, name, options, active_fedora).tap do |reflection|
             add_reflection name, reflection
           end
         else

--- a/lib/active_fedora/aggregation/list_source.rb
+++ b/lib/active_fedora/aggregation/list_source.rb
@@ -1,0 +1,79 @@
+module ActiveFedora
+  module Aggregation
+    class ListSource < ActiveFedora::Base
+      property :head, predicate: ::RDF::Vocab::IANA['first'], multiple: false
+      property :tail, predicate: ::RDF::Vocab::IANA.last, multiple: false
+      property :nodes, predicate: ::RDF::DC::hasPart
+
+      def save(*args)
+        return true if has_unpersisted_proxy_for? || !changed?
+        persist_ordered_self if ordered_self.changed?
+        super
+      end
+
+      def changed?
+        super || ordered_self.changed?
+      end
+
+      # Ordered list representation of proxies in graph.
+      def ordered_self
+        @ordered_self ||= ordered_list_factory.new(resource, head_subject, tail_subject)
+      end
+
+      # Allow this to be set so that -=, += will work.
+      # @param [ActiveFedora::Orders::OrderedList] An ordered list object this
+      #   graph should contain.
+      def ordered_self=(new_ordered_self)
+        @ordered_self = new_ordered_self
+      end
+
+      # Serializing head/tail/nodes slows things down CONSIDERABLY, and is not
+      # useful.
+      # @note This method is used by ActiveFedora::Base upstream for indexing,
+      #   at https://github.com/projecthydra/active_fedora/blob/master/lib/active_fedora/profile_indexing_service.rb.
+      def serializable_hash(options=nil)
+        options ||= {}
+        options[:except] ||= []
+        options[:except] += [:head, :tail, :nodes]
+        super
+      end
+
+      private
+
+      def persist_ordered_self
+        nodes_will_change!
+        # Delete old statements
+        ordered_list_factory.new(resource, head_subject, tail_subject).to_graph.statements.each do |s|
+          resource.delete s
+        end
+        # Assert head and tail
+        self.head = ordered_self.head.next.rdf_subject
+        self.tail = ordered_self.tail.prev.rdf_subject
+        graph = ordered_self.to_graph
+        resource << graph
+        # Set node subjects to a term in AF JUST so that AF will persist the
+        # sub-graphs.
+        # TODO: Find a way to fix this.
+        self.nodes = nil
+        self.nodes += graph.subjects.to_a
+        ordered_self.changes_committed!
+      end
+
+      def has_unpersisted_proxy_for?
+        ordered_self.flat_map(&:target).compact.select(&:new_record?).find{|x| x.respond_to?(:uri)}
+      end
+
+      def head_subject
+        head_id.first
+      end
+
+      def tail_subject
+        tail_id.first
+      end
+
+      def ordered_list_factory
+        ActiveFedora::Orders::OrderedList
+      end
+    end
+  end
+end

--- a/lib/active_fedora/aggregation/ordered_reader.rb
+++ b/lib/active_fedora/aggregation/ordered_reader.rb
@@ -1,4 +1,6 @@
 module ActiveFedora::Aggregation
+  ##
+  # Lazily iterates over a doubly linked list, fixing up nodes if necessary.
   class OrderedReader
     include Enumerable
     attr_reader :root
@@ -9,8 +11,12 @@ module ActiveFedora::Aggregation
     def each
       proxy = first_head
       while proxy
-        yield proxy.target
-        proxy = proxy.next
+        yield proxy unless proxy.nil?
+        next_proxy = proxy.next
+        if next_proxy && next_proxy.prev != proxy
+          next_proxy.try(:prev=, proxy)
+        end
+        proxy = next_proxy
       end
     end
 

--- a/lib/active_fedora/orders.rb
+++ b/lib/active_fedora/orders.rb
@@ -1,0 +1,15 @@
+module ActiveFedora
+  module Orders
+    extend ActiveSupport::Autoload
+
+    eager_autoload do
+      autoload :AggregationBuilder
+      autoload :Association
+      autoload :Builder
+      autoload :CollectionProxy
+      autoload :Reflection
+      autoload :ListNode
+      autoload :OrderedList
+    end
+  end
+end

--- a/lib/active_fedora/orders/aggregation_builder.rb
+++ b/lib/active_fedora/orders/aggregation_builder.rb
@@ -1,0 +1,42 @@
+module ActiveFedora::Orders
+  class AggregationBuilder < ActiveFedora::Associations::Builder::Association
+    self.valid_options = [:through, :class_name, :has_member_relation]
+
+    def self.build(model, name, options)
+      new(model, name, options).build
+    end
+
+    def build
+      model.indirectly_contains name, has_member_relation: has_member_relation, through: proxy_class, foreign_key: proxy_foreign_key, inserted_content_relation: inserted_content_relation
+      model.contains contains_key, class_name: list_source_class
+      model.orders name, through: contains_key
+    end
+
+    private
+
+    def has_member_relation
+      options[:has_member_relation] || ::RDF::DC.hasPart
+    end
+
+    def inserted_content_relation
+      ::RDF::Vocab::ORE::proxyFor
+    end
+
+    def proxy_class
+      "ActiveFedora::Aggregation::Proxy"
+    end
+
+    def proxy_foreign_key
+      :target
+    end
+
+    def contains_key
+      options[:through]
+    end
+
+    def list_source_class
+      "ActiveFedora::Aggregation::ListSource"
+    end
+  end
+end
+

--- a/lib/active_fedora/orders/association.rb
+++ b/lib/active_fedora/orders/association.rb
@@ -1,0 +1,125 @@
+module ActiveFedora::Orders
+  class Association < ::ActiveFedora::Associations::CollectionAssociation
+
+    def initialize(*args)
+      super
+      @target = find_target
+    end
+
+    def reader(*args)
+      @proxy ||= ActiveFedora::Orders::CollectionProxy.new(self)
+      super
+    end
+
+    def target_reader
+      ordered_proxies.flat_map(&:target).to_a
+    end
+
+    def find_reflection
+      reflection
+    end
+
+    def replace(new_ordered_list)
+      raise unless new_ordered_list.kind_of? ActiveFedora::Orders::OrderedList
+      list_container.ordered_self = new_ordered_list
+      @target = find_target
+    end
+
+
+    def find_target
+      ordered_proxies
+    end
+
+    def load_target
+      @target = find_target
+    end
+
+    # Append a target node to the end of the order.
+    # @param [ActiveFedora::Base] record Record to append
+    def append_target(record, skip_callbacks=false, &block)
+      unless unordered_association.target.include?(record)
+        unordered_association.concat(record)
+      end
+      target.append_target(record, proxy_in: owner)
+    end
+
+    # Insert a target node in a specific position
+    # @param [Integer] loc Position to insert record.
+    # @param [ActiveFedora::Base] record Record to insert
+    def insert_target_at(loc, record)
+      unless unordered_association.target.include?(record)
+        unordered_association.concat(record)
+      end
+      target.insert_at(loc, record)
+    end
+
+    # Delete whatever node is at a specific position
+    # @param [Integer] loc Position to delete
+    def delete_at(loc)
+      target.delete_at(loc)
+    end
+
+    # Delete multiple list nodes.
+    # @param [Array<ActiveFedora::Orders::ListNode>] records
+    def delete_records(records, _method)
+      records.each do |record|
+        delete_record(record)
+      end
+    end
+
+    # Delete a list node
+    # @param [ActiveFedora::Orders::ListNode] record Node to delete.
+    def delete_record(record)
+      list_container.delete_node(record)
+    end
+
+    def insert_record(record, force=true, validate=true)
+      record.save_target
+      list_container.save
+      # NOTE: This turns out to be pretty cheap, but should we be doing it
+      # elsewhere?
+      unless list_container.changed?
+        owner.head = list_container.head_id.first
+        owner.tail = list_container.tail_id.first
+        owner.save
+      end
+    end
+
+    def scope(*args)
+      @scope ||= ActiveFedora::Relation.new(klass)
+    end
+
+    private
+
+    def ordered_proxies
+      list_container.ordered_self
+    end
+
+    def create_list_node(record)
+      node = ListNode.new(RDF::URI.new("#{list_container.uri}##{::RDF::Node.new.id}"), list_container.resource)
+      node.proxyIn = owner
+      node.proxyFor = record
+      node
+    end
+
+    def association_scope
+      nil
+    end
+
+    def list_container
+      list_container_association.reader
+    end
+    
+    def list_container_association
+      owner.association(options[:through])
+    end
+
+    def unordered_association
+      owner.association(ordered_reflection_name)
+    end
+
+    def ordered_reflection_name
+      reflection.ordered_reflection.name
+    end
+  end
+end

--- a/lib/active_fedora/orders/builder.rb
+++ b/lib/active_fedora/orders/builder.rb
@@ -1,0 +1,36 @@
+module ActiveFedora::Orders
+  class Builder < ActiveFedora::Associations::Builder::CollectionAssociation
+    include ActiveFedora::AutosaveAssociation::AssociationBuilderExtension
+    self.macro = :orders
+    self.valid_options += [:through, :ordered_reflection]
+
+    def self.define_readers(mixin, name)
+      super
+      mixin.redefine_method("#{name.to_s.gsub("_proxies","").pluralize}") do
+        association(name).target_reader
+      end
+    end
+
+    def initialize(model, name, options)
+      @original_name = name
+      @model = model
+      name = :"ordered_#{name.to_s.singularize}_proxies"
+      options = {ordered_reflection: ordered_reflection}.merge(options)
+      super
+    end
+
+    def build
+      super.tap do
+        model.property :head, predicate: ::RDF::Vocab::IANA['first'], multiple: false
+        model.property :tail, predicate: ::RDF::Vocab::IANA.last, multiple: false
+      end
+    end
+
+    private
+
+    def ordered_reflection
+      model.reflect_on_association(@original_name)
+    end
+  end
+end
+

--- a/lib/active_fedora/orders/collection_proxy.rb
+++ b/lib/active_fedora/orders/collection_proxy.rb
@@ -1,0 +1,8 @@
+module ActiveFedora
+  module Orders
+    class CollectionProxy < ActiveFedora::Associations::CollectionProxy
+      attr_reader :association
+      delegate :append_target, :insert_target_at, :delete_at, to: :association
+    end
+  end
+end

--- a/lib/active_fedora/orders/list_node.rb
+++ b/lib/active_fedora/orders/list_node.rb
@@ -1,0 +1,128 @@
+module ActiveFedora::Orders
+  class ListNode
+    attr_reader :rdf_subject
+    attr_accessor :prev, :next, :target
+    attr_writer :next_uri, :prev_uri
+    attr_accessor :proxy_in, :proxy_for
+    def initialize(node_cache, rdf_subject, graph=RDF::Graph.new)
+      @rdf_subject = rdf_subject
+      @graph = graph
+      @node_cache = node_cache
+      Builder.new(rdf_subject, graph).populate(self)
+    end
+
+    # Returns the next proxy or a tail sentinel.
+    # @return [ActiveFedora::Orders::ListNode]
+    def next
+      @next ||=
+        if next_uri
+          node_cache.fetch(next_uri) do
+            node = self.class.new(node_cache, next_uri, graph)
+            node.prev = self
+            node
+          end
+        end
+    end
+
+    # Returns the previous proxy or a head sentinel.
+    # @return [ActiveFedora::Orders::ListNode]
+    def prev
+      @prev ||=
+        if prev_uri
+          node_cache.fetch(prev_uri) do
+            node = self.class.new(node_cache, prev_uri, graph)
+            node.next = self
+            node
+          end
+        end
+    end
+
+    # Graph representation of node.
+    # @return [ActiveFedora::Orders::ListNode::Resource]
+    def to_graph
+      g = Resource.new(rdf_subject)
+      g.proxy_for = target.try(:uri)
+      g.proxy_in = proxy_in.try(:uri)
+      g.next = self.next.try(:rdf_subject)
+      g.prev = self.prev.try(:rdf_subject)
+      g
+    end
+
+    # Object representation of proxyFor
+    # @return [ActiveFedora::Base]
+    def target
+      @target ||= 
+        if proxy_for.present?
+          node_cache.fetch(proxy_for) do
+            ActiveFedora::Base.from_uri(proxy_for, nil)
+          end
+        end
+    end
+
+    # Persists target if it's been accessed or set.
+    def save_target
+      if @target
+        @target.save
+      else
+        true
+      end
+    end
+
+
+    # Methods necessary for association functionality
+    def destroyed?
+      false
+    end
+
+    def marked_for_destruction?
+      false
+    end
+
+    def valid?
+      true
+    end
+
+    def changed_for_autosave?
+      true
+    end
+
+    def new_record?
+      @target && @target.new_record?
+    end
+
+    private
+
+    attr_reader :next_uri, :prev_uri, :graph, :node_cache
+
+    class Builder
+      attr_reader :uri, :graph
+      def initialize(uri, graph)
+        @uri = uri
+        @graph = graph
+      end
+
+      def populate(instance)
+        instance.proxy_for = resource.proxy_for.first
+        instance.proxy_in = resource.proxy_in.first
+        instance.next_uri = resource.next.first
+        instance.prev_uri = resource.prev.first
+      end
+
+      private
+
+      def resource
+        @resource ||= Resource.new(uri, graph)
+      end
+    end
+
+    class Resource < ActiveTriples::Resource
+      property :proxy_for, predicate: ::RDF::Vocab::ORE.proxyFor, cast: false
+      property :proxy_in, predicate: ::RDF::Vocab::ORE.proxyIn, cast: false
+      property :next, predicate: ::RDF::Vocab::IANA.next, cast: false
+      property :prev, predicate: ::RDF::Vocab::IANA.prev, cast: false
+      def final_parent
+        parent
+      end
+    end
+  end
+end

--- a/lib/active_fedora/orders/ordered_list.rb
+++ b/lib/active_fedora/orders/ordered_list.rb
@@ -1,0 +1,237 @@
+module ActiveFedora
+  module Orders
+    ##
+    # Ruby object representation of an ORE doubly linked list.
+    class OrderedList
+      include Enumerable
+      attr_reader :graph, :head_subject, :tail_subject
+      attr_writer :head, :tail
+      delegate :each, to: :ordered_reader
+      delegate :length, to: :to_a
+      # @param [::RDF::Enumerable] graph Enumerable where ORE statements are
+      #   stored.
+      # @param [::RDF::URI] head_subject URI of head node in list.
+      # @param [::RDF::URI] tail_subject URI of tail node in list.
+      def initialize(graph, head_subject, tail_subject)
+        @graph = graph
+        @head_subject = head_subject
+        @tail_subject = tail_subject
+        @node_cache ||= NodeCache.new
+        @changed = false
+        tail
+      end
+
+      # @return [HeadSentinel] Sentinel for the top of the list. If not empty,
+      #  head.next is the first element.
+      def head
+        @head ||= HeadSentinel.new(self, next_node: build_node(head_subject))
+      end
+
+      # @return [TailSentinel] Sentinel for the bottom of the list. If not
+      #   empty, tail.prev is the first element.
+      def tail
+        @tail ||= 
+          begin
+            if tail_subject
+              TailSentinel.new(self, prev_node: build_node(tail_subject))
+            else
+              head.next
+            end
+          end
+      end
+
+      # @param [Integer] key Position of the proxy
+      # @return [ListNode] Node for the proxy at the given position
+      def [](key)
+        list = ordered_reader.take(key+1)
+        list[key]
+      end
+
+      # @return [ListNode] Last node in the list.
+      def last
+        if empty?
+          nil
+        else
+          tail.prev
+        end
+      end
+
+      # @param [Array<ListNode>] Nodes to remove.
+      # @return [OrderedList] List with node removed.
+      def -(nodes)
+        nodes.each do |node|
+          delete_node(node)
+        end
+        self
+      end
+
+      # @return [Boolean]
+      def empty?
+        head.next == tail
+      end
+
+      # @param [ActiveFedora::Base] target Target to append to list.
+      # @option [::RDF::URI, ActiveFedora::Base] :proxy_in Proxy in to 
+      #   assert on the created node.
+      def append_target(target, proxy_in: nil)
+        node = build_node(new_node_subject)
+        node.target = target
+        node.proxy_in = proxy_in
+        append_to(node, tail.prev)
+      end
+
+      # @param [Integer] loc Location to insert target at
+      # @param [ActiveFedora::Base] target Target to insert
+      def insert_at(loc, target)
+        node = build_node(new_node_subject)
+        node.target = target
+        if loc == 0
+          append_to(node, head)
+        else
+          append_to(node, ordered_reader.take(loc).last)
+        end
+      end
+
+      # @param [ListNode] node Node to delete
+      def delete_node(node)
+        node = ordered_reader.find{|x| x == node}
+        if node
+          prev_node = node.prev
+          next_node = node.next
+          node.prev.next = next_node
+          node.next.prev = prev_node
+          @changed = true
+        end
+        self
+      end
+
+      # @param [Integer] loc Index of node to delete.
+      def delete_at(loc)
+        return self if loc == nil
+        arr = ordered_reader.take(loc+1)
+        if arr.length == loc+1
+          delete_node(arr.last)
+        else
+          self
+        end
+      end
+
+      # @return [Boolean] Whether this list was changed since instantiation.
+      def changed?
+        @changed
+      end
+
+      # @return [::RDF::Graph] Graph representation of this list.
+      def to_graph
+        ::RDF::Graph.new.tap do |g|
+          array = to_a
+          array.map(&:to_graph).each do |resource_graph|
+            g << resource_graph
+          end
+        end
+      end
+
+      # Marks this list as not changed.
+      def changes_committed!
+        @changed = false
+      end
+
+      private
+
+      attr_reader :node_cache
+
+      def append_to(source, append_node)
+        source.prev = append_node
+        if append_node.next
+          append_node.next.prev = source
+          source.next = append_node.next
+        else
+          self.tail = source
+        end
+        append_node.next = source
+        @changed = true
+      end
+
+      def ordered_reader
+        ActiveFedora::Aggregation::OrderedReader.new(self)
+      end
+
+      def build_node(subject=nil)
+        return nil unless subject
+        node_cache.fetch(subject) do
+          ActiveFedora::Orders::ListNode.new(node_cache, subject, graph)
+        end
+      end
+
+      def new_node_subject
+        node = ::RDF::URI("##{::RDF::Node.new.id}")
+        while node_cache.has_key?(node)
+          node = ::RDF::URI("##{::RDF::Node.new.id}")
+        end
+        node
+      end
+
+      class NodeCache
+        def initialize
+          @cache ||= {}
+        end
+
+        def fetch(uri)
+          if @cache[uri]
+            @cache[uri]
+          else
+            if block_given?
+              @cache[uri] = yield
+            end
+          end
+        end
+
+        def has_key?(key)
+          @cache.has_key?(key)
+        end
+      end
+
+      class Sentinel
+        attr_reader :parent
+        attr_writer :next, :prev
+        def initialize(parent, next_node: nil, prev_node: nil)
+          @parent = parent
+          @next = next_node
+          @prev = prev_node
+        end
+
+        def next
+          @next
+        end
+
+        def prev
+          @prev
+        end
+
+        def nil?
+          true
+        end
+
+        def rdf_subject
+          nil
+        end
+      end
+
+      class HeadSentinel < Sentinel
+        def initialize(*args)
+          super
+          @next ||= TailSentinel.new(parent, prev_node: self)
+        end
+      end
+
+      class TailSentinel < Sentinel
+        def initialize(*args)
+          super
+          if prev && prev.next != self
+            prev.next = self
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/active_fedora/orders/reflection.rb
+++ b/lib/active_fedora/orders/reflection.rb
@@ -1,0 +1,24 @@
+module ActiveFedora::Orders
+  class Reflection < ActiveFedora::Reflection::AssociationReflection
+    def association_class
+      Association
+    end
+
+    def collection?
+      true
+    end
+
+    def class_name
+      klass.to_s
+    end
+
+    def ordered_reflection
+      options[:ordered_reflection]
+    end
+
+    def klass
+      ActiveFedora::Orders::ListNode
+    end
+  end
+end
+

--- a/spec/active_fedora/aggregation/list_source_spec.rb
+++ b/spec/active_fedora/aggregation/list_source_spec.rb
@@ -1,0 +1,109 @@
+require 'spec_helper'
+
+RSpec.describe ActiveFedora::Aggregation::ListSource do
+  subject { described_class.new }
+  
+  describe "#head" do
+    it "should be nil by default" do
+      expect(subject.head).to eq nil
+    end
+
+    it "is settable" do
+      subject.head = RDF::URI("test.org")
+
+      expect(subject.head_id.first).to eq RDF::URI("test.org")
+    end
+
+    it "maps to IANA.first" do
+      expect(subject.class.properties["head"].predicate).to eq ::RDF::Vocab::IANA["first"]
+    end
+  end
+
+  describe "#tail" do
+    it "should be nil by default" do
+      expect(subject.tail).to eq nil
+    end
+
+    it "is settable" do
+      subject.tail = RDF::URI("test.org")
+
+      expect(subject.tail_id.first).to eq RDF::URI("test.org")
+    end
+
+    it "maps to IANA.last" do
+      expect(subject.class.properties["tail"].predicate).to eq ::RDF::Vocab::IANA["last"]
+    end
+  end
+
+  describe "#changed?" do
+    context "when nothing has changed" do
+      it "is false" do
+        expect(subject).not_to be_changed
+      end
+    end
+    context "when the ordered list is changed" do
+      it "is true" do
+        allow(subject.ordered_self).to receive(:changed?).and_return(true)
+
+        expect(subject).to be_changed
+      end
+    end
+    context "when the ordered list is not changed" do
+      it "is false" do
+        allow(subject.ordered_self).to receive(:changed?).and_return(false)
+
+        expect(subject).not_to be_changed
+      end
+    end
+  end
+
+  describe "#save" do
+    context "when nothing has changed" do
+      it "does not persist ordered_self" do
+        allow(subject.ordered_self).to receive(:to_graph)
+
+        subject.save
+
+        expect(subject.ordered_self).not_to have_received(:to_graph)
+      end
+    end
+    context "when attributes have changed, but not ordered list" do
+      it "does not persist ordered self" do
+        allow(subject.ordered_self).to receive(:to_graph)
+        subject.nodes += [RDF::URI("http://test.org")]
+
+        subject.save
+
+        expect(subject.ordered_self).not_to have_received(:to_graph)
+      end
+    end
+    context "when ordered list has changed" do
+      it "should persist it" do
+        allow(subject.ordered_self).to receive(:to_graph).and_call_original
+        allow(subject.ordered_self).to receive(:changed?).and_return(true)
+
+        subject.save
+
+        expect(subject.ordered_self).to have_received(:to_graph)
+      end
+    end
+  end
+
+  describe "#serializable_hash" do
+    it "does not serialize nodes" do
+      subject.nodes += [RDF::URI("http://test.org")]
+
+      expect(subject.serializable_hash).not_to have_key "nodes"
+    end
+    it "does not serialize head" do
+      subject.head = RDF::URI("http://test.org")
+
+      expect(subject.serializable_hash).not_to have_key "head"
+    end
+    it "does not serialize tail" do
+      subject.tail = RDF::URI("http://test.org")
+
+      expect(subject.serializable_hash).not_to have_key "tail"
+    end
+  end
+end

--- a/spec/active_fedora/aggregation/ordered_reader_spec.rb
+++ b/spec/active_fedora/aggregation/ordered_reader_spec.rb
@@ -1,0 +1,43 @@
+require 'spec_helper'
+
+RSpec.describe ActiveFedora::Aggregation::OrderedReader do
+  subject { described_class.new(root) }
+  let(:root) { instance_double(ActiveFedora::Aggregation::ListSource) }
+
+  describe "#each" do
+    it "should iterate a linked list" do
+      head = build_node
+      tail = build_node(prev_node: head)
+      allow(head).to receive(:next).and_return(tail)
+      allow(root).to receive(:head).and_return(head)
+      expect(subject.to_a).to eq [head, tail]
+    end
+    it "should only go as deep as necessary" do
+      head = build_node
+      tail = build_node(prev_node: head)
+      allow(head).to receive(:next).and_return(tail)
+      allow(root).to receive(:head).and_return(head)
+      expect(subject.first).to eq head
+      expect(head).not_to have_received(:next)
+    end
+    context "when the prev is wrong" do
+      it "fixes it up" do
+        head = build_node
+        bad_node = build_node
+        tail = build_node(prev_node: bad_node)
+        allow(head).to receive(:next).and_return(tail)
+        allow(root).to receive(:head).and_return(head)
+        allow(tail).to receive(:prev=)
+        expect(subject.to_a).to eq [head, tail]
+        expect(tail).to have_received(:prev=).with(head)
+      end
+    end
+  end
+
+  def build_node(prev_node: nil, next_node: nil)
+    node = instance_double(ActiveFedora::Orders::ListNode)
+    allow(node).to receive(:next).and_return(next_node)
+    allow(node).to receive(:prev).and_return(prev_node)
+    node
+  end
+end

--- a/spec/active_fedora/orders/list_node_spec.rb
+++ b/spec/active_fedora/orders/list_node_spec.rb
@@ -1,0 +1,46 @@
+require 'spec_helper'
+
+RSpec.describe ActiveFedora::Orders::ListNode do
+  subject { described_class.new(node_cache, rdf_subject, graph) }
+  let(:node_cache) { {} }
+  let(:rdf_subject) { RDF::URI("#bla") }
+  let(:graph) { RDF::Graph.new }
+  
+  describe "#target" do
+    context "when a target is set" do
+      it "returns it" do
+        member = instance_double("member")
+        subject.target = member
+        expect(subject.target).to eq member
+      end
+    end
+    context "when no target is set" do
+      context "and it's not in the graph" do
+        it "returns nil" do
+          expect(subject.target).to eq nil
+        end
+      end
+      context "and it's set in the graph" do
+        before do
+          class Member < ActiveFedora::Base
+          end
+        end
+        after do
+          Object.send(:remove_const, :Member)
+        end
+        it "returns it" do
+          member = Member.create
+          graph << [rdf_subject, RDF::Vocab::ORE.proxyFor, member.resource.rdf_subject]
+          expect(subject.target).to eq member
+        end
+        context "and it doesn't exist" do
+          it "returns an AT::Resource" do
+            member = Member.new("testing")
+            graph << [rdf_subject, RDF::Vocab::ORE.proxyFor, member.resource.rdf_subject]
+            expect(subject.target.rdf_subject).to eq member.uri
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/active_fedora/orders/ordered_list_spec.rb
+++ b/spec/active_fedora/orders/ordered_list_spec.rb
@@ -1,0 +1,267 @@
+require 'spec_helper'
+
+RSpec.describe ActiveFedora::Orders::OrderedList do
+  subject { described_class.new(graph, head_uri, tail_uri) }
+
+  let(:graph) { ActiveTriples::Resource.new(RDF::URI("stuff"))}
+  let(:head_uri) { nil }
+  let(:tail_uri) { nil }
+  describe "#last" do
+    context "with no nodes" do
+      it "is nil" do
+        expect(subject.last).to eq nil
+      end
+    end
+    context "with one node" do
+      it "is that node" do
+        member = instance_double(ActiveFedora::Base)
+        subject.append_target member
+
+        expect(subject.last.target).to eq member
+      end
+    end
+    context "with two nodes" do
+      it "is the last node" do
+        member = instance_double(ActiveFedora::Base)
+        member_2 = instance_double(ActiveFedora::Base)
+        subject.append_target member
+        subject.append_target member_2
+
+        expect(subject.last.target).to eq member_2
+      end
+    end
+  end
+
+  describe "#[]" do
+    context "with no nodes" do
+      it "is always nil" do
+        expect(subject[0]).to eq nil
+      end
+    end
+    context "with two nodes" do
+      let(:member) { instance_double(ActiveFedora::Base) }
+      let(:member_2) { instance_double(ActiveFedora::Base) }
+      before do
+        subject.append_target member
+        subject.append_target member_2
+      end
+      it "can return the first" do
+        expect(subject[0].target).to eq member
+      end
+      it "can return the last" do
+        expect(subject[1].target).to eq member_2
+      end
+      it "returns nil for out of bounds values" do
+        expect(subject[3]).to eq nil
+      end
+    end
+  end
+  describe "#first" do
+    context "with no nodes" do
+      it "is nil" do
+        expect(subject.first).to eq nil
+      end
+    end
+    context "with a node" do
+      it "returns that node" do
+        member = instance_double(ActiveFedora::Base)
+        subject.append_target member
+        expect(subject.first.target).to eq member
+        expect(subject).to be_changed
+      end
+    end
+    context "with an item from the graph" do
+      let(:head_uri) { RDF::URI.new("parent#bla") }
+      let(:tail_uri) { RDF::URI.new("parent#bla") }
+      it "builds the node" do
+        node_subject = RDF::URI.new("parent#bla")
+        member_uri = RDF::URI.new("member1")
+        parent_uri = RDF::URI.new("parent")
+        graph << [node_subject, RDF::Vocab::ORE.proxyFor, member_uri]
+        graph << [node_subject, RDF::Vocab::ORE.proxyIn, parent_uri]
+        expect(subject.first.proxy_for).to eq member_uri
+        expect(subject.first.proxy_in).to eq parent_uri
+        expect(subject.first).not_to eq nil
+      end
+      it "is changed by a delete" do
+        node_subject = RDF::URI.new("parent#bla")
+        member_uri = RDF::URI.new("member1")
+        parent_uri = RDF::URI.new("parent")
+        graph << [node_subject, RDF::Vocab::ORE.proxyFor, member_uri]
+        graph << [node_subject, RDF::Vocab::ORE.proxyIn, parent_uri]
+
+        expect(subject).not_to be_changed
+        subject.delete_at(0)
+        expect(subject).to be_changed
+      end
+      context "with multiple nodes" do
+        let(:tail_uri) { RDF::URI.new("parent#bla2") }
+        it "can build multiple nodes" do
+          node_subject = RDF::URI.new("parent#bla")
+          node_2_subject = RDF::URI.new("parent#bla2")
+          member_uri = RDF::URI.new("member1")
+          parent_uri = RDF::URI.new("parent")
+          graph << [node_subject, RDF::Vocab::ORE.proxyFor, member_uri]
+          graph << [node_subject, RDF::Vocab::ORE.proxyIn, parent_uri]
+          graph << [node_subject, RDF::Vocab::IANA.next, node_2_subject]
+          graph << [node_2_subject, RDF::Vocab::IANA.prev, node_subject]
+          graph << [node_2_subject, RDF::Vocab::ORE.proxyFor, member_uri]
+          graph << [node_2_subject, RDF::Vocab::ORE.proxyIn, parent_uri]
+          expect(subject.length).to eq 2
+          expect(subject.tail.prev.prev).to eq subject.head.next
+          expect(subject.map(&:target).map(&:rdf_subject)).to eq [member_uri, member_uri]
+          expect(subject).not_to be_changed
+        end
+      end
+    end
+  end
+
+  describe "#append_target" do
+    it "should be able to append multiple targets" do
+      member = instance_double(ActiveFedora::Base)
+      proxy_in = instance_double(ActiveFedora::Base, uri: RDF::URI("obj1"))
+      600.times do
+        subject.append_target member, proxy_in: proxy_in
+      end
+      expect(subject.length).to eq 600
+      expect(subject.to_a.last.next).not_to eq nil
+      expect(subject.to_a.last.proxy_in).to eq proxy_in
+    end
+  end
+
+  describe "#insert_at" do
+    it "can insert in the middle" do
+      member = instance_double(ActiveFedora::Base)
+      member_2 = instance_double(ActiveFedora::Base)
+      3.times do
+        subject.append_target member
+      end
+
+      subject.insert_at(1, member_2)
+
+      expect(subject.to_a.map(&:target)).to eq [member, member_2, member, member]
+      expect(subject).to be_changed
+    end
+    it "can insert at the beginning" do
+      member = instance_double(ActiveFedora::Base)
+      member_2 = instance_double(ActiveFedora::Base)
+      2.times do
+        subject.append_target member
+      end
+
+      subject.insert_at(0, member_2)
+
+      expect(subject.to_a.map(&:target)).to eq [member_2, member, member]
+    end
+  end
+
+  describe "#delete_node" do
+    it "can delete a node in the middle" do
+      member = instance_double(ActiveFedora::Base)
+      member_2 = instance_double(ActiveFedora::Base)
+      subject.append_target member
+      subject.append_target member_2
+      subject.append_target member
+
+      subject.delete_node(subject.to_a[1])
+
+      expect(subject.map(&:target)).to eq [member, member]
+    end
+    it "can delete a node at the start" do
+      member = instance_double(ActiveFedora::Base)
+      member_2 = instance_double(ActiveFedora::Base)
+      subject.append_target member_2
+      subject.append_target member
+      subject.append_target member
+
+      subject.delete_node(subject.to_a[0])
+
+      expect(subject.map(&:target)).to eq [member, member]
+    end
+    it "can delete a node at the end" do
+      member = instance_double(ActiveFedora::Base)
+      member_2 = instance_double(ActiveFedora::Base)
+      subject.append_target member
+      subject.append_target member
+      subject.append_target member_2
+
+      subject.delete_node(subject.to_a[2])
+
+      expect(subject.map(&:target)).to eq [member, member]
+    end
+  end
+
+  describe "#delete_at" do
+    it "can delete a node in the middle" do
+      member = instance_double(ActiveFedora::Base)
+      member_2 = instance_double(ActiveFedora::Base)
+      subject.append_target member
+      subject.append_target member_2
+      subject.append_target member
+
+      subject.delete_at(1)
+
+      expect(subject.map(&:target)).to eq [member, member]
+    end
+    it "can delete a node at the start" do
+      member = instance_double(ActiveFedora::Base)
+      member_2 = instance_double(ActiveFedora::Base)
+      subject.append_target member_2
+      subject.append_target member
+      subject.append_target member
+
+      subject.delete_at(0)
+
+      expect(subject.map(&:target)).to eq [member, member]
+    end
+    it "can delete a node at the end" do
+      member = instance_double(ActiveFedora::Base)
+      member_2 = instance_double(ActiveFedora::Base)
+      subject.append_target member
+      subject.append_target member
+      subject.append_target member_2
+
+      subject.delete_at(2)
+
+      expect(subject.map(&:target)).to eq [member, member]
+    end
+    it "does not delete nodes if the loc is out of bounds" do
+      member = instance_double(ActiveFedora::Base)
+      member_2 = instance_double(ActiveFedora::Base)
+      subject.append_target member
+      subject.append_target member
+      subject.append_target member_2
+
+      subject.delete_at(3)
+      subject.delete_at(nil)
+
+      expect(subject.map(&:target)).to eq [member, member, member_2]
+    end
+  end
+
+  describe "#to_graph" do
+    it "creates a good graph" do
+      member = instance_double(ActiveFedora::Base, uri: RDF::URI("http://test.org"))
+      owner = instance_double(ActiveFedora::Base, uri: RDF::URI("http://owner.org"))
+      subject.append_target member
+      subject.append_target member, proxy_in: owner
+
+      graph = subject.to_graph
+
+      expect(graph.statements.to_a.length).to eq 5
+      expect(graph.subjects.to_a).to eq subject.to_a.map(&:rdf_subject)
+    end
+  end
+
+  describe "#changes_committed!" do
+    it "should set changed back to false" do
+      member = instance_double(ActiveFedora::Base, uri: RDF::URI("http://test.org"))
+      subject.append_target member
+      expect(subject).to be_changed
+
+      subject.changes_committed!
+
+      expect(subject).not_to be_changed
+    end
+  end
+end

--- a/spec/active_fedora/orders/reflection_spec.rb
+++ b/spec/active_fedora/orders/reflection_spec.rb
@@ -1,0 +1,21 @@
+require 'spec_helper'
+
+RSpec.describe ActiveFedora::Orders::Reflection do
+  subject { described_class.new(macro, name, options, active_fedora) }
+  let(:macro) { :orders }
+  let(:name) { "ordered_member_proxies" }
+  let(:options) { {} }
+  let(:active_fedora) { double("active_fedora") }
+
+  describe "#klass" do
+    it "should be a proxy" do
+      expect(subject.klass).to eq ActiveFedora::Orders::ListNode
+    end
+  end
+
+  describe "#class_name" do
+    it "should be a list node" do
+      expect(subject.class_name).to eq "ActiveFedora::Orders::ListNode"
+    end
+  end
+end

--- a/spec/activefedora/ordered_spec.rb
+++ b/spec/activefedora/ordered_spec.rb
@@ -1,0 +1,169 @@
+require 'spec_helper'
+
+RSpec.describe "orders" do
+  subject { Image.new }
+  before do
+    class Member < ActiveFedora::Base
+    end
+    class BadClass < ActiveFedora::Base
+    end
+    class Image < ActiveFedora::Base
+      ordered_aggregation :members, through: :list_source
+    end
+  end
+  after do
+    Object.send(:remove_const, :Image)
+    Object.send(:remove_const, :Member)
+    Object.send(:remove_const, :BadClass)
+  end
+  describe "<<" do
+    it "should not accept base objects" do
+      member = Member.new
+      expect{subject.ordered_member_proxies << member}.to raise_error ActiveFedora::AssociationTypeMismatch
+      expect(subject).not_to be_changed
+      expect(subject.list_source).not_to be_changed
+    end
+  end
+  describe "append_target" do
+    it "doesn't add all members" do
+      member = Member.new
+      subject.members << member
+      expect(subject.ordered_members).to eq []
+    end
+    it "can handle adding many objects" do
+      member = Member.new
+      60.times do
+        subject.ordered_member_proxies.append_target member
+      end
+      expect(subject.ordered_member_proxies.to_a.length).to eq 60
+    end
+    it "can't add items not accepted by indirect container" do
+      bad_class = BadClass.new
+      expect{subject.ordered_member_proxies.append_target bad_class}.to raise_error ActiveFedora::AssociationTypeMismatch
+    end
+    it "adds a member if it doesn't exist in members" do
+      member = Member.new
+      subject.ordered_member_proxies.append_target member
+      expect(subject.members).to eq [member]
+      expect(subject.ordered_members).to eq [member]
+    end
+    it "doesn't add a member twice" do
+      member = Member.new
+      subject.ordered_member_proxies.append_target member
+      subject.ordered_member_proxies.append_target member
+      expect(subject.members).to eq [member]
+      expect(subject.ordered_members).to eq [member, member]
+    end
+    it "survives persistence" do
+      member = Member.new
+      subject.ordered_member_proxies.append_target member
+      subject.ordered_member_proxies.append_target member
+      subject.save
+      subject.reload
+      expect(subject.ordered_members).to eq [member, member]
+      expect(subject.list_source.resource.query([nil, ::RDF::Vocab::ORE.proxyIn, subject.resource.rdf_subject]).to_a.length).to eq 2
+      expect(subject.head_id).to eq subject.list_source.head_id
+      expect(subject.tail_id).to eq subject.list_source.tail_id
+    end
+    it "can add already persisted items" do
+      member = Member.create
+      subject.ordered_member_proxies.append_target member
+      subject.save
+      subject.reload
+      expect(subject.ordered_members).to eq [member]
+    end
+    it "can append to a pre-persisted item" do
+      member = Member.new
+      subject.ordered_member_proxies.append_target member
+      subject.save
+      subject.reload
+      member_2 = Member.new
+      subject.ordered_member_proxies.append_target member_2
+      subject.save
+      subject.reload
+      expect(subject.ordered_members).to eq [member, member_2]
+    end
+  end
+  describe "insert_target_at" do
+    it "can add between items" do
+      member = Member.new
+      member2 = Member.new
+      subject.ordered_member_proxies.append_target member
+      subject.ordered_member_proxies.append_target member
+      subject.ordered_member_proxies.insert_target_at(1, member2)
+      expect(subject.ordered_members).to eq [member, member2, member]
+      subject.save
+      subject.reload
+      expect(subject.ordered_members).to eq [member, member2, member]
+      subject.ordered_member_proxies.insert_target_at(2, member2)
+      subject.save
+      subject.reload
+      expect(subject.ordered_members).to eq [member, member2, member2, member]
+    end
+  end
+  describe "-=" do
+    it "can remove proxies" do
+      member = Member.new
+      subject.ordered_member_proxies.append_target member
+      subject.ordered_member_proxies -= [subject.ordered_member_proxies.last]
+      expect(subject.ordered_members).to eq []
+      expect(subject.list_source.resource.statements.to_a.length).to eq 1
+    end
+    it "can remove proxies in the middle" do
+      member = Member.new
+      member_2 = Member.new
+      subject.ordered_member_proxies.append_target member
+      subject.ordered_member_proxies.append_target member_2
+      subject.ordered_member_proxies.append_target member
+      subject.ordered_member_proxies -= [subject.ordered_member_proxies[1]]
+      expect(subject.ordered_members).to eq [member, member]
+    end
+    it "can remove proxies post-create" do
+      member = Member.new
+      subject.ordered_member_proxies.append_target member
+      subject.ordered_member_proxies.append_target member
+      subject.ordered_member_proxies.append_target member
+      subject.save
+      subject.reload
+      subject.ordered_member_proxies -= [subject.ordered_member_proxies[1]]
+      expect(subject.ordered_members).to eq [member, member]
+      subject.save
+      subject.reload
+      expect(subject.ordered_members).to eq [member, member]
+      # THIS NEEDS TO PASS - can't delete fragment URI resources via sparql
+      # update?
+      # Blocked by https://jira.duraspace.org/browse/FCREPO-1764
+      # expect(subject.list_source.resource.subjects.to_a.length).to eq 5
+    end
+  end
+  describe ".delete_at" do
+    it "can remove in the middle" do
+      member = Member.new
+      subject.ordered_member_proxies.append_target member
+      subject.ordered_member_proxies.append_target member
+      subject.ordered_member_proxies.append_target member
+      subject.ordered_member_proxies.delete_at(1)
+      expect(subject.ordered_members).to eq [member, member]
+    end
+    it "doesn't do anything if passed a bad value" do
+      member = Member.new
+      subject.ordered_member_proxies.append_target member
+      subject.ordered_member_proxies.append_target member
+      subject.ordered_member_proxies.append_target member
+      subject.ordered_member_proxies.delete_at(3)
+      subject.ordered_member_proxies.delete_at(nil)
+      expect(subject.ordered_members).to eq [member, member, member]
+    end
+    it "can persist a deletion" do
+      member = Member.new
+      subject.ordered_member_proxies.append_target member
+      subject.ordered_member_proxies.append_target member
+      subject.ordered_member_proxies.append_target member
+      expect(subject.ordered_members).to eq [member, member, member]
+      subject.ordered_member_proxies.delete_at(1)
+      subject.save
+      subject.reload
+      expect(subject.ordered_members).to eq [member, member]
+    end
+  end
+end


### PR DESCRIPTION
This stops the practice of using the member nodes as proxies and
instead creates proxies inside a contained resource. Provides the
following benefits:
1. Speed up reordering - you now only have to update one item when you
   reorder.
2. Explicit separation allows for easy repeats of the same item in a
   given ordering.
3. When etags are usable this should prevent problems with concurrent
   updates breaking the linked list.

Note: This leaves the old implementation and API behind for backwards
compatibility, but there's no dependency on that code here.
