### PR TITLE
Add indexing and actionable #ordered_members.

### DIFF
--- a/lib/active_fedora/aggregation/base_extension.rb
+++ b/lib/active_fedora/aggregation/base_extension.rb
@@ -16,7 +16,7 @@ module ActiveFedora::Aggregation
     end
 
     def ordered_by
-      ordered_by_ids.map{ |x| ActiveFedora::Base.find(x) }
+      ordered_by_ids.lazy.map{ |x| ActiveFedora::Base.find(x) }
     end
 
     private

--- a/lib/active_fedora/aggregation/base_extension.rb
+++ b/lib/active_fedora/aggregation/base_extension.rb
@@ -15,7 +15,16 @@ module ActiveFedora::Aggregation
       proxy_class.where(proxyFor_ssim: id).map(&:container)
     end
 
+    def ordered_by
+      ordered_by_ids.map{ |x| ActiveFedora::Base.find(x) }
+    end
+
     private
+
+      def ordered_by_ids
+        ActiveFedora::SolrService.query("{!join from=proxy_in_ssi to=id}ordered_targets_ssim:#{id}")
+          .map{|x| x["id"]}
+      end
 
       def proxy_class
         ActiveFedora::Aggregation::Proxy

--- a/lib/active_fedora/aggregation/list_source.rb
+++ b/lib/active_fedora/aggregation/list_source.rb
@@ -38,6 +38,12 @@ module ActiveFedora
         super
       end
 
+      def to_solr(solr_doc={})
+        super.merge({
+          ordered_targets_ssim: ordered_self.target_ids
+        })
+      end
+
       private
 
       def persist_ordered_self

--- a/lib/active_fedora/aggregation/list_source.rb
+++ b/lib/active_fedora/aggregation/list_source.rb
@@ -40,7 +40,8 @@ module ActiveFedora
 
       def to_solr(solr_doc={})
         super.merge({
-          ordered_targets_ssim: ordered_self.target_ids
+          ordered_targets_ssim: ordered_self.target_ids,
+          proxy_in_ssi: ordered_self.proxy_in.to_s
         })
       end
 

--- a/lib/active_fedora/orders.rb
+++ b/lib/active_fedora/orders.rb
@@ -10,6 +10,7 @@ module ActiveFedora
       autoload :Reflection
       autoload :ListNode
       autoload :OrderedList
+      autoload :TargetProxy
     end
   end
 end

--- a/lib/active_fedora/orders/aggregation_builder.rb
+++ b/lib/active_fedora/orders/aggregation_builder.rb
@@ -1,18 +1,25 @@
 module ActiveFedora::Orders
   class AggregationBuilder < ActiveFedora::Associations::Builder::Association
-    self.valid_options = [:through, :class_name, :has_member_relation]
+    self.valid_options = [:through, :class_name, :has_member_relation, :type_validator]
 
     def self.build(model, name, options)
       new(model, name, options).build
     end
 
     def build
-      model.indirectly_contains name, has_member_relation: has_member_relation, through: proxy_class, foreign_key: proxy_foreign_key, inserted_content_relation: inserted_content_relation
+      model.indirectly_contains name, {has_member_relation: has_member_relation, through: proxy_class, foreign_key: proxy_foreign_key, inserted_content_relation: inserted_content_relation}.merge(indirect_options)
       model.contains contains_key, class_name: list_source_class
       model.orders name, through: contains_key
     end
 
     private
+
+    def indirect_options
+      {
+        class_name: options[:class_name],
+        type_validator: options[:type_validator]
+      }.select{ |k, v| v.present? }
+    end
 
     def has_member_relation
       options[:has_member_relation] || ::RDF::DC.hasPart

--- a/lib/active_fedora/orders/association.rb
+++ b/lib/active_fedora/orders/association.rb
@@ -12,7 +12,32 @@ module ActiveFedora::Orders
     end
 
     def target_reader
-      ordered_proxies.flat_map(&:target).to_a
+      @target_proxy ||= TargetProxy.new(self)
+    end
+
+    class TargetProxy
+      attr_reader :association
+      def initialize(association)
+        @association = association
+      end
+
+      def <<(obj)
+        association.append_target(obj)
+      end
+
+      def to_ary
+        association.reader.map(&:target).dup
+      end
+      alias_method :to_a, :to_ary
+
+      def ==(other_obj)
+        case other_obj
+        when TargetProxy
+          super
+        when Array
+          to_a == other_obj
+        end
+      end
     end
 
     def find_reflection

--- a/lib/active_fedora/orders/association.rb
+++ b/lib/active_fedora/orders/association.rb
@@ -15,31 +15,6 @@ module ActiveFedora::Orders
       @target_proxy ||= TargetProxy.new(self)
     end
 
-    class TargetProxy
-      attr_reader :association
-      def initialize(association)
-        @association = association
-      end
-
-      def <<(obj)
-        association.append_target(obj)
-      end
-
-      def to_ary
-        association.reader.map(&:target).dup
-      end
-      alias_method :to_a, :to_ary
-
-      def ==(other_obj)
-        case other_obj
-        when TargetProxy
-          super
-        when Array
-          to_a == other_obj
-        end
-      end
-    end
-
     def find_reflection
       reflection
     end

--- a/lib/active_fedora/orders/list_node.rb
+++ b/lib/active_fedora/orders/list_node.rb
@@ -81,6 +81,19 @@ module ActiveFedora::Orders
       end
     end
 
+    def proxy_in_id
+      uri = nil
+      if @proxy_in && proxy_in.respond_to?(:id)
+        uri = proxy_in.id
+      elsif proxy_in
+        uri = proxy_in
+      end
+      ActiveFedora::Associations::IDComposite.new(
+        [uri],
+        ActiveFedora::Base.translate_uri_to_id
+      ).to_a.first
+    end
+
 
     # Methods necessary for association functionality
     def destroyed?

--- a/lib/active_fedora/orders/list_node.rb
+++ b/lib/active_fedora/orders/list_node.rb
@@ -59,6 +59,19 @@ module ActiveFedora::Orders
         end
     end
 
+    def target_id
+      uri = nil
+      if @target
+        uri = target.id
+      elsif proxy_for
+        uri = proxy_for
+      end
+      ActiveFedora::Associations::IDComposite.new(
+        [uri],
+        ActiveFedora::Base.translate_uri_to_id
+      ).to_a.first
+    end
+
     # Persists target if it's been accessed or set.
     def save_target
       if @target

--- a/lib/active_fedora/orders/ordered_list.rb
+++ b/lib/active_fedora/orders/ordered_list.rb
@@ -136,6 +136,11 @@ module ActiveFedora
         @changed = false
       end
 
+      # Returns the IDs of all ordered targets, in order
+      def target_ids
+        to_a.map(&:target_id)
+      end
+
       private
 
       attr_reader :node_cache

--- a/lib/active_fedora/orders/ordered_list.rb
+++ b/lib/active_fedora/orders/ordered_list.rb
@@ -136,9 +136,20 @@ module ActiveFedora
         @changed = false
       end
 
-      # Returns the IDs of all ordered targets, in order
+      # @return IDs of all ordered targets, in order
       def target_ids
         to_a.map(&:target_id)
+      end
+
+      # @return The node all proxies are a proxy in.
+      # @note If there are multiple proxy_ins this will log a warning and return
+      #   the first.
+      def proxy_in
+        proxies = to_a.map(&:proxy_in_id).compact.uniq
+        if proxies.length > 1
+          ActiveFedora::Base.logger.warn "WARNING: List contains nodes aggregated under different URIs. Returning only the first." if ActiveFedora::Base.logger
+        end
+        proxies.first
       end
 
       private

--- a/lib/active_fedora/orders/target_proxy.rb
+++ b/lib/active_fedora/orders/target_proxy.rb
@@ -1,0 +1,28 @@
+module ActiveFedora
+  module Orders
+    class TargetProxy
+      attr_reader :association
+      def initialize(association)
+        @association = association
+      end
+
+      def <<(obj)
+        association.append_target(obj)
+      end
+
+      def to_ary
+        association.reader.map(&:target).dup
+      end
+      alias_method :to_a, :to_ary
+
+      def ==(other_obj)
+        case other_obj
+        when TargetProxy
+          super
+        when Array
+          to_a == other_obj
+        end
+      end
+    end
+  end
+end

--- a/spec/active_fedora/aggregation/list_source_spec.rb
+++ b/spec/active_fedora/aggregation/list_source_spec.rb
@@ -106,4 +106,23 @@ RSpec.describe ActiveFedora::Aggregation::ListSource do
       expect(subject.serializable_hash).not_to have_key "tail"
     end
   end
+
+  describe "#to_solr" do
+    before do
+      class Member < ActiveFedora::Base
+      end
+    end
+    after do
+      Object.send(:remove_const, :Member)
+    end
+    it "can index" do
+      m = Member.create
+      subject.ordered_self.append_target m
+      expect(subject.to_solr).to include (
+        {
+          ordered_targets_ssim: [m.id]
+        }
+      )
+    end
+  end
 end

--- a/spec/active_fedora/aggregation/list_source_spec.rb
+++ b/spec/active_fedora/aggregation/list_source_spec.rb
@@ -117,10 +117,12 @@ RSpec.describe ActiveFedora::Aggregation::ListSource do
     end
     it "can index" do
       m = Member.create
-      subject.ordered_self.append_target m
+      proxy_in = RDF::URI("http://localhost:8983/fedora/rest/test/banana")
+      subject.ordered_self.append_target m, proxy_in: proxy_in
       expect(subject.to_solr).to include (
         {
-          ordered_targets_ssim: [m.id]
+          ordered_targets_ssim: [m.id],
+          proxy_in_ssi: "banana"
         }
       )
     end

--- a/spec/active_fedora/orders/list_node_spec.rb
+++ b/spec/active_fedora/orders/list_node_spec.rb
@@ -43,4 +43,41 @@ RSpec.describe ActiveFedora::Orders::ListNode do
       end
     end
   end
+
+  describe "#target_id" do
+    context "when a target is set" do
+      it "returns its id" do
+        member = instance_double("member", id: "member1")
+        subject.target = member
+        expect(subject.target_id).to eq "member1"
+      end
+    end
+    context "when a target is from the graph" do
+      before do
+        class Member < ActiveFedora::Base
+        end
+      end
+      after do
+        Object.send(:remove_const, :Member)
+      end
+      context "and it's cached but missing" do
+        it "works" do
+          member = Member.create
+          graph << [rdf_subject, RDF::Vocab::ORE.proxyFor, member.resource.rdf_subject]
+          allow(ActiveFedora::Base).to receive(:from_uri).and_return(ActiveTriples::Resource.new(member.resource.rdf_subject))
+          subject.target
+
+          expect(subject.target_id).to eq member.id
+        end
+      end
+      it "doesn't re-ify the target" do
+        member = Member.create
+        graph << [rdf_subject, RDF::Vocab::ORE.proxyFor, member.resource.rdf_subject]
+        allow(ActiveFedora::Base).to receive(:from_uri).and_call_original
+
+        expect(subject.target_id).to eq member.id
+        expect(ActiveFedora::Base).not_to have_received(:from_uri)
+      end
+    end
+  end
 end

--- a/spec/active_fedora/orders/list_node_spec.rb
+++ b/spec/active_fedora/orders/list_node_spec.rb
@@ -80,4 +80,40 @@ RSpec.describe ActiveFedora::Orders::ListNode do
       end
     end
   end
+  describe "#proxy_in_id" do
+    context "when a target is set" do
+      it "returns its id" do
+        member = instance_double("member", id: "member1")
+        subject.proxy_in = member
+        expect(subject.proxy_in_id).to eq "member1"
+      end
+    end
+    context "when a proxy_in is from the graph" do
+      before do
+        class Member < ActiveFedora::Base
+        end
+      end
+      after do
+        Object.send(:remove_const, :Member)
+      end
+      context "and it's cached but missing" do
+        it "works" do
+          member = Member.create
+          graph << [rdf_subject, RDF::Vocab::ORE.proxyIn, member.resource.rdf_subject]
+          allow(ActiveFedora::Base).to receive(:from_uri).and_return(ActiveTriples::Resource.new(member.resource.rdf_subject))
+          subject.target
+
+          expect(subject.proxy_in_id).to eq member.id
+        end
+      end
+      it "doesn't re-ify the target" do
+        member = Member.create
+        graph << [rdf_subject, RDF::Vocab::ORE.proxyIn, member.resource.rdf_subject]
+        allow(ActiveFedora::Base).to receive(:from_uri).and_call_original
+
+        expect(subject.proxy_in_id).to eq member.id
+        expect(ActiveFedora::Base).not_to have_received(:from_uri)
+      end
+    end
+  end
 end

--- a/spec/active_fedora/orders/ordered_list_spec.rb
+++ b/spec/active_fedora/orders/ordered_list_spec.rb
@@ -32,6 +32,32 @@ RSpec.describe ActiveFedora::Orders::OrderedList do
     end
   end
 
+  describe "#target_ids" do
+    context "from a graph" do
+      let(:head_uri) { RDF::URI.new("parent#bla") }
+      let(:tail_uri) { RDF::URI.new("parent#bla") }
+      it "returns the IDs without building the object" do
+        node_subject = RDF::URI.new("parent#bla")
+        member_uri = RDF::URI.new("http://localhost:8983/fedora/rest/test/member1")
+        parent_uri = RDF::URI.new("parent")
+        graph << [node_subject, RDF::Vocab::ORE.proxyFor, member_uri]
+        graph << [node_subject, RDF::Vocab::ORE.proxyIn, parent_uri]
+        allow(ActiveFedora::Base).to receive(:from_uri)
+
+        expect(subject.target_ids).to eq ["member1"]
+        expect(ActiveFedora::Base).not_to have_received(:from_uri)
+      end
+    end
+    context "from a built up list" do
+      it "returns the IDs" do
+        member = instance_double(ActiveFedora::Base, id: "member1")
+        subject.append_target member
+
+        expect(subject.target_ids).to eq ["member1"]
+      end
+    end
+  end
+
   describe "#[]" do
     context "with no nodes" do
       it "is always nil" do

--- a/spec/active_fedora/orders/ordered_list_spec.rb
+++ b/spec/active_fedora/orders/ordered_list_spec.rb
@@ -58,6 +58,38 @@ RSpec.describe ActiveFedora::Orders::OrderedList do
     end
   end
 
+  describe "#proxy_in" do
+    context "when there's one proxy in" do
+      it "returns it" do
+        member = instance_double(ActiveFedora::Base)
+        subject.append_target member, proxy_in: RDF::URI("http://tar.dis")
+
+        expect(subject.proxy_in).to eq RDF::URI("http://tar.dis")
+      end
+    end
+    context "when the proxy in is an AF::Base object" do
+      it "returns the ID" do
+        member = instance_double(ActiveFedora::Base)
+        owner = instance_double(ActiveFedora::Base, id: "member1")
+        subject.append_target member, proxy_in: owner
+
+        expect(subject.proxy_in).to eq "member1"
+      end
+    end
+    context "when there's two proxy ins" do
+      it "returns the first and throws a warning" do
+        member = instance_double(ActiveFedora::Base)
+        subject.append_target member, proxy_in: RDF::URI("http://tar.dis")
+        subject.append_target member, proxy_in: RDF::URI("http://tar.di")
+        ActiveFedora::Base.logger = Logger.new(STDERR)
+        allow(ActiveFedora::Base.logger).to receive(:warn)
+
+        expect(subject.proxy_in).to eq RDF::URI("http://tar.dis")
+        expect(ActiveFedora::Base.logger).to have_received(:warn).with("WARNING: List contains nodes aggregated under different URIs. Returning only the first.")
+      end
+    end
+  end
+
   describe "#[]" do
     context "with no nodes" do
       it "is always nil" do

--- a/spec/activefedora/ordered_spec.rb
+++ b/spec/activefedora/ordered_spec.rb
@@ -35,7 +35,7 @@ RSpec.describe "orders" do
         image.save
         puts image.id
 
-        expect(m.ordered_by).to eq [image]
+        expect(m.ordered_by.to_a).to eq [image]
       end
     end
 

--- a/spec/activefedora/ordered_spec.rb
+++ b/spec/activefedora/ordered_spec.rb
@@ -24,6 +24,18 @@ RSpec.describe "orders" do
       expect(subject.list_source).not_to be_changed
     end
   end
+
+  describe "#ordered_members" do
+    describe "<<" do
+      it "can append" do
+        member = Member.new
+        subject.ordered_members << member
+        expect(subject.ordered_members).to eq [member]
+        expect(subject.members).to eq [member]
+        expect(subject.ordered_member_proxies.to_a.length).to eq 1
+      end
+    end
+  end
   describe "append_target" do
     it "doesn't add all members" do
       member = Member.new

--- a/spec/activefedora/ordered_spec.rb
+++ b/spec/activefedora/ordered_spec.rb
@@ -25,6 +25,33 @@ RSpec.describe "orders" do
     end
   end
 
+  describe "ordered_by" do
+    let(:image) { Image.new }
+
+    context "an element aggregated by one record" do
+      it "can find the record that contains it" do
+        m = Member.create
+        image.ordered_members << m
+        image.save
+        puts image.id
+
+        expect(m.ordered_by).to eq [image]
+      end
+    end
+
+    context "an element aggregated by multiple records" do
+      let(:image2) { Image.new }
+      it "can find all of the records that contain it" do
+        m = Member.create
+        image.ordered_members << m
+        image2.ordered_members << m
+        image.save
+        image2.save
+        expect(m.ordered_by).to contain_exactly(image2,image)
+      end
+    end
+  end
+
   describe "#ordered_members" do
     describe "<<" do
       it "can append" do


### PR DESCRIPTION
These fixes are largely to support APIs expected by Hydra::PCDM.
