### PR TITLE
Don't track previous_changes. It's expensive

### DIFF
--- a/lib/active_fedora/aggregation/list_source.rb
+++ b/lib/active_fedora/aggregation/list_source.rb
@@ -11,6 +11,12 @@ module ActiveFedora
         super
       end
 
+      # Overriding so that we don't track previously_changed, which was
+      # rather expensive.
+      def clear_changed_attributes
+        @changed_attributes.clear
+      end
+
       def changed?
         super || ordered_self.changed?
       end


### PR DESCRIPTION
<img width="459" alt="screen shot 2015-10-26 at 8 12 37 pm" src="https://cloud.githubusercontent.com/assets/92044/10746988/16ea0794-7c1e-11e5-9432-9b76ebdd8aa4.png">

Blue is the baseline. The red series is after the patch. X-axis is milliseconds. Smaller is better.
