### PR TITLE
Don't display ordered list for association inspect.

### DIFF
--- a/lib/active_fedora/orders/association.rb
+++ b/lib/active_fedora/orders/association.rb
@@ -6,6 +6,10 @@ module ActiveFedora::Orders
       @target = find_target
     end
 
+    def inspect
+      "#<ActiveFedora::Orders::Association:#{object_id}>"
+    end
+
     def reader(*args)
       @proxy ||= ActiveFedora::Orders::CollectionProxy.new(self)
       super


### PR DESCRIPTION
Avoids accidentally calling #to_a on things like target_reader.
