### PR TITLE
update README Example to current conventions

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ end
 
 generic_file1 = GenericFile.create(id: 'file1')
 generic_file2 = GenericFile.create(id: 'file2')
-generic_file3 = GenericFile.create(id: 'file2')
+generic_file3 = GenericFile.create(id: 'file3')
 
 class Image < ActiveFedora::Base
   ordered_aggregation :generic_files, through: :list_source
@@ -25,20 +25,21 @@ image = Image.create(id: 'my_image')
 image.ordered_generic_file_proxies.append_target generic_file2
 image.ordered_generic_file_proxies.append_target generic_file1
 image.save
-image.generic_files # => [generic_file2, generic_file]
-image.ordered_generic_files # => [generic_file2, generic_file]
+image.generic_files # => [#<GenericFile id: "file2">, #<GenericFile id: "file1">]
+image.ordered_generic_files.to_a # => [#<GenericFile id: "file2">, #<GenericFile id: "file1">]
 
 # Not all generic files must be ordered.
 image.generic_files += [generic_file3]
-image.generic_files # => [generic_file2, generic_file, generic_file3]
-image.ordered_generic_files # => [generic_file2, generic_file]
+image.generic_files => [#<GenericFile id: "file2">, #<GenericFile id: "file1">, #<GenericFile id: "file3">]
+image.ordered_generic_files.to_a => [#<GenericFile id: "file2">, #<GenericFile id: "file1">]
 
 # non-ordered accessor is not ordered.
-image.ordered_generic_file_proxies.insert_at(0, generic_file3)
-image.generic_files # => [generic_file2, generic_file, generic_file3]
-image.ordered_generic_files # => [generic_file3, generic_file2, generic_file]
+image.ordered_generic_file_proxies.insert_target_at(0, generic_file3)
+image.generic_files # => [#<GenericFile id: "file2">, #<GenericFile id: "file1">, #<GenericFile id: "file3">]
+image.ordered_generic_files.to_a # => [#<GenericFile id: "file3">, #<GenericFile id: "file2">, #<GenericFile id: "file1">] 
 
 # Deletions
-image.ordered_generic_file_proxies.delete_at(1)
-image.ordered_generic_files # => [generic_file3, generic_file]
+image.ordered_generic_file_proxies.delete_at(1) => #<GenericFile id: "file2">
+image.ordered_generic_files.to_a # => [#<GenericFile id: "file3">, #<GenericFile id: "file1">]
+image.generic_files # => [#<GenericFile id: "file2">, #<GenericFile id: "file1">, #<GenericFile id: "file3">]
 ```


### PR DESCRIPTION
updated README to fix a few typos and reflect what I believe to be the current conventions illustrated in the example. primary changes:
- references to `generic_file` should have been `generic_file1`
- `generic_file3` id value set to 'file3'
- `#ordered_generic_files` call now include `#to_a` to match example output
- `#insert_at` is not available for [CollectionProxy](https://github.com/projecthydra-labs/activefedora-aggregation/blob/master/lib/active_fedora/orders/collection_proxy.rb#L5). Changed example to use `#insert_target_at` which seems to support the intended behavior in the example.
- `#generic_files` example added to Deletions example to show that only the ordered proxy received the deletion
